### PR TITLE
Improve strictness

### DIFF
--- a/core-test/test/Test/Fold.hs
+++ b/core-test/test/Test/Fold.hs
@@ -2,13 +2,18 @@
 
 module Test.Fold where
 
-import Data.Proxy
-import Hedgehog
+import Control.Category (Category (..))
+import Control.Monad ((=<<))
+import Data.Bool (Bool)
+import Data.Function (($))
+import Data.Proxy (Proxy (..))
+import Hedgehog (Property, checkParallel, discover, forAll, property)
 import qualified Hedgehog.Gen as Gen
-import Yaya.Fold
-import Yaya.Fold.Common
-import Yaya.Hedgehog.Expr
-import Yaya.Hedgehog.Fold
+import System.IO (IO)
+import Yaya.Fold (Mu)
+import Yaya.Fold.Common (size)
+import Yaya.Hedgehog.Expr (Expr, genExpr, genMuExpr)
+import Yaya.Hedgehog.Fold (law_cataCancel, law_cataCompose, law_cataRefl)
 
 prop_muCataCancel :: Property
 prop_muCataCancel =

--- a/core-test/test/Test/Fold/Common.hs
+++ b/core-test/test/Test/Fold/Common.hs
@@ -2,11 +2,19 @@
 
 module Test.Fold.Common where
 
-import Hedgehog
+import Control.Category (Category (..))
+import Control.Monad ((=<<))
+import Data.Bool (Bool)
+import Data.Functor (Functor (..))
+import Data.Ord (Ord (..))
+import Hedgehog (Property, assert, checkParallel, discover, forAll, property)
 import qualified Hedgehog.Gen as Gen
-import Yaya.Fold
-import Yaya.Fold.Common
-import Yaya.Hedgehog.Expr
+import System.IO (IO)
+import Yaya.Fold (Recursive (..), zipAlgebras)
+import Yaya.Fold.Common (height, size)
+import Yaya.Hedgehog.Expr (genMuExpr)
+import Yaya.Pattern (uncurry)
+import Prelude (Integral (..))
 
 prop_heightLtSize :: Property
 prop_heightLtSize =

--- a/core-test/test/Test/Retrofit.hs
+++ b/core-test/test/Test/Retrofit.hs
@@ -1,3 +1,4 @@
+-- These are both needed by `extractPatternFunctor`.
 {-# LANGUAGE DeriveTraversable #-}
 {-# LANGUAGE TemplateHaskell #-}
 
@@ -5,8 +6,13 @@
 --   other Yaya modules.
 module Test.Retrofit where
 
-import Hedgehog
-import Yaya.Retrofit
+import Data.Bool (Bool)
+import Data.Eq (Eq)
+import Data.Int (Int)
+import Hedgehog (checkParallel, discover)
+import System.IO (IO)
+import Text.Show (Show)
+import Yaya.Retrofit (defaultRules, extractPatternFunctor)
 
 data DExpr
   = Lit Int

--- a/core-test/test/test.hs
+++ b/core-test/test/test.hs
@@ -1,6 +1,8 @@
-import Control.Monad
+import Control.Monad (unless)
+import Data.Foldable (and)
+import Data.Traversable (sequenceA)
 import System.Exit (exitFailure)
-import System.IO (BufferMode (..), hSetBuffering, stderr, stdout)
+import System.IO (BufferMode (..), IO, hSetBuffering, stderr, stdout)
 import qualified Test.Fold as Fold
 import qualified Test.Fold.Common as Fold.Common
 import qualified Test.Retrofit as Retrofit
@@ -11,7 +13,7 @@ main = do
   hSetBuffering stderr LineBuffering
 
   results <-
-    sequence
+    sequenceA
       [ Fold.tests,
         Fold.Common.tests,
         Retrofit.tests

--- a/core-test/yaya-test.cabal
+++ b/core-test/yaya-test.cabal
@@ -37,6 +37,8 @@ test-suite yaya-test
                      , yaya-hedgehog >= 0.2.0
   default-extensions:  LambdaCase
                      , MultiParamTypeClasses
+                     , StrictData
+                     , NoImplicitPrelude
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N -Wall
   default-language:    Haskell2010
 

--- a/core/src/Yaya/Applied.hs
+++ b/core/src/Yaya/Applied.hs
@@ -1,10 +1,38 @@
 module Yaya.Applied where
 
-import Control.Monad.Trans.Free
-import Data.Functor.Identity
+import Control.Applicative (Applicative)
+import Control.Category (Category (..))
+import Control.Monad.Trans.Free (FreeF (..))
+import Data.Foldable (Foldable (..))
+import Data.Functor (Functor (..))
+import Data.Functor.Identity (Identity (..))
+import Data.Int (Int)
+import Data.Ord (Ord (..))
+import Data.Traversable (Traversable)
 import Yaya.Fold
+  ( Algebra,
+    Corecursive (..),
+    Mu,
+    Projectable (..),
+    Recursive (..),
+    Steppable (..),
+    cata2,
+  )
 import Yaya.Fold.Common
-import Yaya.Pattern
+  ( diagonal,
+    fromEither,
+    lucasSequence',
+    maybeTakeNext,
+    never,
+    takeAnother,
+    takeAvailable,
+    takeNext,
+    toRight,
+    truncate',
+    unarySequence,
+  )
+import Yaya.Pattern (Either (..), Maybe (..), Pair, XNor, maybe)
+import Prelude (Integral)
 
 now :: Steppable (->) t (Either a) => a -> t
 now = embed . Left
@@ -106,7 +134,7 @@ mersenne :: (Integral i, Corecursive (->) t ((,) i)) => t
 mersenne = lucasSequenceU 3 2
 
 -- | Creates an infinite stream of the provided value.
-constantly :: Corecursive (->) t ((,) a) => a -> t
+constantly :: Corecursive (->) t (Pair a) => a -> t
 constantly = ana diagonal
 
 -- | Lops off the branches of the tree below a certain depth, turning a

--- a/core/src/Yaya/Experimental/Foldable.hs
+++ b/core/src/Yaya/Experimental/Foldable.hs
@@ -6,10 +6,14 @@
 --   class can be implemented in the as in @base@.
 module Yaya.Experimental.Foldable where
 
-import Control.Monad.Trans.Free
-import Yaya.Fold
-import Yaya.Fold.Common
-import Yaya.Pattern
+import Control.Category (Category (..))
+import Control.Monad.Trans.Free (Free, iter)
+import Data.Function (flip)
+import Data.Monoid (Monoid)
+import Data.String (String)
+import Yaya.Fold (Recursive (..))
+import Yaya.Fold.Common (lowerMonoid)
+import Yaya.Pattern (XNor (..))
 
 foldMap :: (Recursive (->) t (XNor a), Monoid m) => (a -> m) -> t -> m
 foldMap = cata . lowerMonoid

--- a/core/src/Yaya/Fold/Common.hs
+++ b/core/src/Yaya/Fold/Common.hs
@@ -1,20 +1,39 @@
 -- | Common algebras that are useful when folding.
 module Yaya.Fold.Common where
 
-import Control.Monad
-import Control.Monad.Trans.Free
-import Data.Foldable
-import Data.Functor.Classes
-import Data.Functor.Day
-import Data.Functor.Identity
-import Numeric.Natural
+import Control.Applicative (Applicative (..))
+import Control.Category (Category (..))
+import Control.Monad (Monad, join)
+import Control.Monad.Trans.Free (FreeF (..))
+import Data.Bool (Bool (..), (&&))
+import Data.Eq (Eq (..))
+import Data.Foldable (Foldable (..), and)
+import Data.Function (($))
+import Data.Functor (Functor (..), void)
+import Data.Functor.Classes (Eq1 (..))
+import Data.Functor.Day (Day (..))
+import Data.Functor.Identity (Identity (..))
+import Data.List (zipWith)
+import Data.Monoid (Monoid (..))
+import Data.Ord (Ord (..))
+import Data.Semigroup (Semigroup (..))
+import Numeric.Natural (Natural)
 import Yaya.Pattern
+  ( AndMaybe (..),
+    Either (..),
+    Maybe (..),
+    Pair (..),
+    XNor (..),
+    either,
+    maybe,
+  )
+import Prelude (Integer, Integral, Num (..))
 
 -- | Converts the free monoid (a list) into some other `Monoid`.
 lowerMonoid :: Monoid m => (a -> m) -> XNor a m -> m
 lowerMonoid f = \case
   Neither -> mempty
-  Both a b -> mappend (f a) b
+  Both a b -> f a <> b
 
 -- | Converts the free semigroup (a non-empty list) into some other `Semigroup`.
 lowerSemigroup :: Semigroup m => (a -> m) -> AndMaybe a m -> m
@@ -105,8 +124,8 @@ truncate' = \case
 
 -- | Converts a single value into a tuple with the same value on both sides.
 --   > x &&& y = (x *** y) . diagonal
-diagonal :: a -> (a, a)
-diagonal x = (x, x)
+diagonal :: a -> Pair a a
+diagonal x = x :!: x
 
 -- * sequence generators
 

--- a/core/src/Yaya/Functor.hs
+++ b/core/src/Yaya/Functor.hs
@@ -4,6 +4,7 @@ module Yaya.Functor where
 
 import Control.Applicative.Backwards (Backwards (..))
 import Control.Applicative.Lift (Lift (..))
+import Control.Category (Category (..))
 import qualified Control.Monad.Trans.Except as Ex
 import qualified Control.Monad.Trans.Identity as I
 import qualified Control.Monad.Trans.Maybe as M
@@ -14,7 +15,9 @@ import qualified Control.Monad.Trans.State.Lazy as S
 import qualified Control.Monad.Trans.State.Strict as S'
 import qualified Control.Monad.Trans.Writer.Lazy as W'
 import qualified Control.Monad.Trans.Writer.Strict as W
-import Data.Bifunctor
+import Data.Bifunctor (Bifunctor, first)
+import Data.Function (($))
+import Data.Functor (Functor (..))
 import Data.Functor.Compose (Compose (..))
 import Data.Functor.Product (Product (..))
 import Data.Kind (Type)

--- a/core/src/Yaya/Pattern.hs
+++ b/core/src/Yaya/Pattern.hs
@@ -1,12 +1,33 @@
-{-# LANGUAGE StrictData #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 -- | Common pattern functors (and instances for them).
-module Yaya.Pattern where
+--
+--   This re-exports the functors from the strict library because it also adds
+--   some orphan instances for them.
+module Yaya.Pattern
+  ( module Data.Strict.Either,
+    module Data.Strict.Maybe,
+    module Data.Strict.Tuple,
+    XNor (..),
+    AndMaybe (..),
+  )
+where
 
-import Data.Bifunctor
+import Control.Applicative (Applicative (..))
+import Control.Comonad (Comonad (..))
+import Control.Monad (Monad (..))
+import Data.Bifunctor (Bifunctor (..))
+import Data.Foldable (Foldable)
+import Data.Function (($))
+import Data.Functor (Functor)
+import Data.Strict.Either -- explicitly omitted import list
+import Data.Strict.Maybe -- explicitly omitted import list
+import Data.Strict.Tuple -- explicitly omitted import list
+import Data.Traversable (Traversable)
 
 -- | Isomorphic to 'Maybe (a, b)', it’s also the pattern functor for lists.
-data XNor a b = Neither | Both ~a b deriving (Functor, Foldable, Traversable)
+data XNor a b = Neither | Both ~a b
+  deriving (Functor, Foldable, Traversable)
 
 instance Bifunctor XNor where
   bimap f g = \case
@@ -22,3 +43,32 @@ instance Bifunctor AndMaybe where
   bimap f g = \case
     Only a -> Only (f a)
     Indeed a b -> Indeed (f a) (g b)
+
+-- * orphan instances for types from the strict library
+
+-- TODO: Explain why these instances are actually legit (fast & loose).
+
+instance Applicative (Either a) where
+  pure = Right
+  liftA2 f = curry $ \case
+    Right x :!: Right y -> Right $ f x y
+    Right _ :!: Left a -> Left a
+    Left a :!: _ -> Left a
+
+instance Monad (Either a) where
+  Left a >>= _ = Left a
+  Right b >>= f = f b
+
+instance Applicative Maybe where
+  pure = Just
+  liftA2 f = curry $ \case
+    Just x :!: Just y -> Just $ f x y
+    _ :!: _ -> Nothing
+
+instance Monad Maybe where
+  Nothing >>= _ = Nothing
+  Just a >>= f = f a
+
+instance Comonad (Pair a) where
+  extract = snd
+  duplicate x@(a :!: _) = a :!: x

--- a/core/yaya.cabal
+++ b/core/yaya.cabal
@@ -53,6 +53,7 @@ library
                      , kan-extensions
                      , lens
                      , profunctors
+                     , strict
                      , template-haskell
                      , th-abstraction
                      , transformers
@@ -67,8 +68,8 @@ library
                      , RankNTypes
                      , ScopedTypeVariables
                      , StrictData
-                     , TupleSections
                      , TypeOperators
+                     , NoImplicitPrelude
   default-language:    Haskell2010
 
 source-repository head

--- a/flake.lock
+++ b/flake.lock
@@ -2,43 +2,21 @@
   "nodes": {
     "bash-strict-mode": {
       "inputs": {
-        "flake-utils": "flake-utils",
-        "home-manager": "home-manager",
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "flaky": "flaky",
         "nixpkgs": [
           "nixpkgs"
         ],
         "shellcheck-nix-attributes": "shellcheck-nix-attributes"
       },
       "locked": {
-        "lastModified": 1688323758,
-        "narHash": "sha256-E8EYaEwYnirzVs8iQplmd+BIyVttZjody2Ws52M5Er8=",
+        "lastModified": 1697833583,
+        "narHash": "sha256-7JgBrzm0z2UEcvnmIfO/F6KbKPK2/WkT5Kz58Ax2sWA=",
         "owner": "sellout",
         "repo": "bash-strict-mode",
-        "rev": "944d321afc55fc3f539d2d5e9bd314ec5b6824d3",
-        "type": "github"
-      },
-      "original": {
-        "owner": "sellout",
-        "repo": "bash-strict-mode",
-        "type": "github"
-      }
-    },
-    "bash-strict-mode_2": {
-      "inputs": {
-        "flake-utils": "flake-utils_2",
-        "home-manager": "home-manager_2",
-        "nixpkgs": [
-          "concat",
-          "nixpkgs"
-        ],
-        "shellcheck-nix-attributes": "shellcheck-nix-attributes_2"
-      },
-      "locked": {
-        "lastModified": 1674014107,
-        "narHash": "sha256-UgrmDzeSp+li0/wtn0zRZicqy2595bUftW1bMBfP+5Y=",
-        "owner": "sellout",
-        "repo": "bash-strict-mode",
-        "rev": "da573e33174d7078e62eb2a9d9eb7d662e5b4913",
+        "rev": "7ceb740e985f9f19f3b15a6e476dbce2984c0c13",
         "type": "github"
       },
       "original": {
@@ -49,24 +27,46 @@
     },
     "concat": {
       "inputs": {
-        "bash-strict-mode": "bash-strict-mode_2",
-        "flake-utils": "flake-utils_3",
-        "home-manager": "home-manager_3",
+        "bash-strict-mode": [
+          "bash-strict-mode"
+        ],
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "home-manager": [
+          "home-manager"
+        ],
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1688670394,
-        "narHash": "sha256-jgoFK8Hvz4yRZ7Ixwie5HRIFmE4wRMrQrKu0ZMNnN4w=",
+        "lastModified": 1695193832,
+        "narHash": "sha256-IruO8eq9cwF3Ya4UUcDX3NS4hsndwbMi/TqpHFPMi3Y=",
         "owner": "compiling-to-categories",
         "repo": "concat",
-        "rev": "4fc2b2f07006de41364645c1749dc78f5e8f028a",
+        "rev": "5d670b96cd770c6b96f55429bd3a830322ffaf16",
         "type": "github"
       },
       "original": {
         "owner": "compiling-to-categories",
         "repo": "concat",
+        "type": "github"
+      }
+    },
+    "flake-schemas": {
+      "locked": {
+        "lastModified": 1693615451,
+        "narHash": "sha256-rrZipq8J+g+LFWMC0+M0R8+NnZoDdrLHDahcvxh8mgA=",
+        "owner": "DeterminateSystems",
+        "repo": "flake-schemas",
+        "rev": "cfd7826aabef39c337eb79053d0253f446c1c817",
+        "type": "github"
+      },
+      "original": {
+        "owner": "DeterminateSystems",
+        "ref": "support-nixos-modules",
+        "repo": "flake-schemas",
         "type": "github"
       }
     },
@@ -75,11 +75,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1687709756,
-        "narHash": "sha256-Y5wKlQSkgEK2weWdOu4J3riRd+kV/VCgHsqLNTTWQ/0=",
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "dbabf0ca0c0c4bce6ea5eaf65af5cb694d2082c7",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
         "type": "github"
       },
       "original": {
@@ -88,51 +88,30 @@
         "type": "github"
       }
     },
-    "flake-utils_2": {
-      "locked": {
-        "lastModified": 1667395993,
-        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_3": {
-      "locked": {
-        "lastModified": 1676283394,
-        "narHash": "sha256-XX2f9c3iySLCw54rJ/CZs+ZK6IQy7GXNY4nSOyu2QG4=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "3db36a8b464d0c4532ba1c7dda728f4576d6d073",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_4": {
+    "flaky": {
       "inputs": {
-        "systems": "systems_2"
+        "bash-strict-mode": [
+          "bash-strict-mode"
+        ],
+        "flake-utils": [
+          "bash-strict-mode",
+          "flake-utils"
+        ],
+        "home-manager": "home-manager",
+        "nixpkgs": "nixpkgs",
+        "project-manager": "project-manager"
       },
       "locked": {
-        "lastModified": 1687709756,
-        "narHash": "sha256-Y5wKlQSkgEK2weWdOu4J3riRd+kV/VCgHsqLNTTWQ/0=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "dbabf0ca0c0c4bce6ea5eaf65af5cb694d2082c7",
+        "lastModified": 1697832912,
+        "narHash": "sha256-6N7QwbDWlH5oITdPXx1kdcITHQYALRIT1Cf9faDMJz4=",
+        "owner": "sellout",
+        "repo": "flaky",
+        "rev": "33066d3e060b51c194d838be990da97aff591536",
         "type": "github"
       },
       "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
+        "owner": "sellout",
+        "repo": "flaky",
         "type": "github"
       }
     },
@@ -140,15 +119,16 @@
       "inputs": {
         "nixpkgs": [
           "bash-strict-mode",
+          "flaky",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1687871164,
-        "narHash": "sha256-bBFlPthuYX322xOlpJvkjUBz0C+MOBjZdDOOJJ+G2jU=",
+        "lastModified": 1695108154,
+        "narHash": "sha256-gSg7UTVtls2yO9lKtP0yb66XBHT1Fx5qZSZbGMpSn2c=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "07c347bb50994691d7b0095f45ebd8838cf6bc38",
+        "rev": "07682fff75d41f18327a871088d20af2710d4744",
         "type": "github"
       },
       "original": {
@@ -161,62 +141,15 @@
     "home-manager_2": {
       "inputs": {
         "nixpkgs": [
-          "concat",
-          "bash-strict-mode",
-          "nixpkgs"
-        ],
-        "utils": "utils"
-      },
-      "locked": {
-        "lastModified": 1672244468,
-        "narHash": "sha256-xaZb8AZqoXRCSqPusCk4ouf+fUNP8UJdafmMTF1Ltlw=",
-        "owner": "nix-community",
-        "repo": "home-manager",
-        "rev": "89a8ba0b5b43b3350ff2e3ef37b66736b2ef8706",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "ref": "release-22.11",
-        "repo": "home-manager",
-        "type": "github"
-      }
-    },
-    "home-manager_3": {
-      "inputs": {
-        "nixpkgs": [
-          "concat",
-          "nixpkgs"
-        ],
-        "utils": "utils_2"
-      },
-      "locked": {
-        "lastModified": 1676257154,
-        "narHash": "sha256-eW3jymNLpdxS5fkp9NWKyNtgL0Gqtgg1vCTofKXDF1g=",
-        "owner": "nix-community",
-        "repo": "home-manager",
-        "rev": "2cb27c79117a2a75ff3416c3199a2dc57af6a527",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "ref": "release-22.11",
-        "repo": "home-manager",
-        "type": "github"
-      }
-    },
-    "home-manager_4": {
-      "inputs": {
-        "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1687871164,
-        "narHash": "sha256-bBFlPthuYX322xOlpJvkjUBz0C+MOBjZdDOOJJ+G2jU=",
+        "lastModified": 1695108154,
+        "narHash": "sha256-gSg7UTVtls2yO9lKtP0yb66XBHT1Fx5qZSZbGMpSn2c=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "07c347bb50994691d7b0095f45ebd8838cf6bc38",
+        "rev": "07682fff75d41f18327a871088d20af2710d4744",
         "type": "github"
       },
       "original": {
@@ -228,11 +161,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1688759215,
-        "narHash": "sha256-SmVCCTxq2RN0/8WsmUr4Q3+bVnKe7Kt5g704mwZVUdA=",
+        "lastModified": 1697828342,
+        "narHash": "sha256-DSaN5aa+Kyo84GoQL1dIg0H9AMLl8yU4q+uN2AjEi4s=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b4de0d6537df9875e994688d8caf3a1bdfb7a4e9",
+        "rev": "96f7c64907ccdb53e36b3c02b5165dfd491ec0db",
         "type": "github"
       },
       "original": {
@@ -242,32 +175,83 @@
         "type": "github"
       }
     },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1697379843,
+        "narHash": "sha256-RcnGuJgC2K/UpTy+d32piEoBXq2M+nVFzM3ah/ZdJzg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "12bdeb01ff9e2d3917e6a44037ed7df6e6c3df9d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1699548876,
+        "narHash": "sha256-i2Zi1lzKKwDz9tDiZr5nX11irKuwFme0noXb0FF+MWE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c41b26e688ff139e009e756a9b88c2760dfa8350",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "release-23.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "project-manager": {
+      "inputs": {
+        "bash-strict-mode": [
+          "bash-strict-mode",
+          "flaky",
+          "bash-strict-mode"
+        ],
+        "flake-schemas": "flake-schemas",
+        "flake-utils": [
+          "bash-strict-mode",
+          "flaky",
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "bash-strict-mode",
+          "flaky",
+          "nixpkgs"
+        ],
+        "nixpkgs-unstable": "nixpkgs-unstable",
+        "treefmt-nix": "treefmt-nix"
+      },
+      "locked": {
+        "lastModified": 1697773416,
+        "narHash": "sha256-uiRS7byPw0PSRno+Kzvsfvggx8pVCvQtMcocRDTS6ZU=",
+        "owner": "sellout",
+        "repo": "project-manager",
+        "rev": "36d951c1524bc629efa191cfe2e574b92d527843",
+        "type": "github"
+      },
+      "original": {
+        "owner": "sellout",
+        "repo": "project-manager",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "bash-strict-mode": "bash-strict-mode",
         "concat": "concat",
-        "flake-utils": "flake-utils_4",
-        "home-manager": "home-manager_4",
-        "nixpkgs": "nixpkgs"
+        "flake-utils": "flake-utils",
+        "home-manager": "home-manager_2",
+        "nixpkgs": "nixpkgs_2"
       }
     },
     "shellcheck-nix-attributes": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1586929030,
-        "narHash": "sha256-a0WyWaz+nMYFWI43Ip9EUnPuBW0O4EIiTzYZKGqNjss=",
-        "owner": "Fuuzetsu",
-        "repo": "shellcheck-nix-attributes",
-        "rev": "51b49d5fe65ece69eb5e2003396bf096083ec281",
-        "type": "github"
-      },
-      "original": {
-        "owner": "Fuuzetsu",
-        "repo": "shellcheck-nix-attributes",
-        "type": "github"
-      }
-    },
-    "shellcheck-nix-attributes_2": {
       "flake": false,
       "locked": {
         "lastModified": 1586929030,
@@ -298,48 +282,26 @@
         "type": "github"
       }
     },
-    "systems_2": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "bash-strict-mode",
+          "flaky",
+          "project-manager",
+          "nixpkgs"
+        ]
       },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "utils": {
       "locked": {
-        "lastModified": 1667395993,
-        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "lastModified": 1695822946,
+        "narHash": "sha256-IQU3fYo0H+oGlqX5YrgZU3VRhbt2Oqe6KmslQKUO4II=",
         "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "repo": "treefmt-nix",
+        "rev": "720bd006d855b08e60664e4683ccddb7a9ff614a",
         "type": "github"
       },
       "original": {
         "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "utils_2": {
-      "locked": {
-        "lastModified": 1667395993,
-        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
+        "repo": "treefmt-nix",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -205,14 +205,23 @@
 
   inputs = {
     bash-strict-mode = {
-      inputs.nixpkgs.follows = "nixpkgs";
+      inputs = {
+        flake-utils.follows = "flake-utils";
+        home-manager.follows = "home-manager";
+        nixpkgs.follows = "nixpkgs";
+      };
       url = "github:sellout/bash-strict-mode";
     };
 
     # Currently contains our Haskell/Nix lib that should be extracted into its
     # own flake.
     concat = {
-      inputs.nixpkgs.follows = "nixpkgs";
+      inputs = {
+        bash-strict-mode.follows = "bash-strict-mode";
+        flake-utils.follows = "flake-utils";
+        home-manager.follows = "home-manager";
+        nixpkgs.follows = "nixpkgs";
+      };
       url = "github:compiling-to-categories/concat";
     };
 

--- a/garnix.yaml
+++ b/garnix.yaml
@@ -1,5 +1,7 @@
 builds:
-  exclude: []
+  exclude:
+    # TODO: Remove once garnix-io/garnix#285 is fixed.
+    - "homeConfigurations.x86_64-darwin-example"
   include:
     - '*.aarch64-linux'
     - '*.aarch64-linux.*'
@@ -9,4 +11,5 @@ builds:
     - '*.aarch64-darwin.*'
     - '*.x86_64-darwin'
     - '*.x86_64-darwin.*'
+    - 'homeConfigurations.*'
     - 'nixosConfigurations.*'

--- a/hedgehog/src/Yaya/Hedgehog/Expr.hs
+++ b/hedgehog/src/Yaya/Hedgehog/Expr.hs
@@ -1,17 +1,22 @@
-{-# LANGUAGE DeriveTraversable #-}
-{-# LANGUAGE StrictData #-}
 {-# LANGUAGE TemplateHaskell #-}
 
 module Yaya.Hedgehog.Expr where
 
-import Data.Eq.Deriving
-import Hedgehog
+import Control.Applicative (Applicative (..))
+import Data.Eq (Eq)
+import Data.Eq.Deriving (deriveEq1)
+import Data.Foldable (Foldable)
+import Data.Functor (Functor, (<$>))
+import Data.Int (Int)
+import Data.Traversable (Traversable)
+import Hedgehog (Gen, Size)
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
-import Text.Show.Deriving
-import Yaya.Fold
-import Yaya.Fold.Native
-import Yaya.Hedgehog.Fold
+import Text.Show (Show)
+import Text.Show.Deriving (deriveShow1)
+import Yaya.Fold (Mu, Nu, Steppable)
+import Yaya.Fold.Native (Fix)
+import Yaya.Hedgehog.Fold (embeddableOfHeight)
 
 data Expr a
   = Lit Int

--- a/hedgehog/yaya-hedgehog.cabal
+++ b/hedgehog/yaya-hedgehog.cabal
@@ -46,7 +46,7 @@ library
                      , RankNTypes
                      , ScopedTypeVariables
                      , StrictData
-                     , TupleSections
+                     , NoImplicitPrelude
   default-language:    Haskell2010
 
 source-repository head

--- a/unsafe-test/test/Test/Fold.hs
+++ b/unsafe-test/test/Test/Fold.hs
@@ -2,14 +2,19 @@
 
 module Test.Fold where
 
-import Data.Proxy
-import Hedgehog
+import Control.Category (Category (..))
+import Control.Monad ((=<<))
+import Data.Bool (Bool)
+import Data.Function (($))
+import Data.Proxy (Proxy (..))
+import Hedgehog (Property, checkParallel, discover, forAll, property)
 import qualified Hedgehog.Gen as Gen
-import Yaya.Fold
-import Yaya.Fold.Common
-import Yaya.Fold.Native
-import Yaya.Hedgehog.Expr
-import Yaya.Hedgehog.Fold
+import System.IO (IO)
+import Yaya.Fold (Nu)
+import Yaya.Fold.Common (size)
+import Yaya.Fold.Native (Fix)
+import Yaya.Hedgehog.Expr (Expr, genExpr, genFixExpr, genNuExpr)
+import Yaya.Hedgehog.Fold (law_anaRefl, law_cataCancel, law_cataCompose, law_cataRefl)
 import qualified Yaya.Unsafe.Fold.Instances ()
 
 -- | NB: Only in yaya-unsafe instead of yaya because the `Eq (Fix f)` instance

--- a/unsafe-test/test/test.hs
+++ b/unsafe-test/test/test.hs
@@ -1,6 +1,8 @@
-import Control.Monad
+import Control.Monad (unless)
+import Data.Foldable (and)
+import Data.Traversable (sequenceA)
 import System.Exit (exitFailure)
-import System.IO (BufferMode (..), hSetBuffering, stderr, stdout)
+import System.IO (BufferMode (..), IO, hSetBuffering, stderr, stdout)
 import qualified Test.Fold as Fold
 
 main :: IO ()
@@ -9,7 +11,7 @@ main = do
   hSetBuffering stderr LineBuffering
 
   results <-
-    sequence
+    sequenceA
       [ Fold.tests
       ]
 

--- a/unsafe-test/yaya-unsafe-test.cabal
+++ b/unsafe-test/yaya-unsafe-test.cabal
@@ -33,6 +33,8 @@ test-suite yaya-unsafe-test
                      , yaya >= 0.1.0
                      , yaya-hedgehog >= 0.1.2
                      , yaya-unsafe >= 0.1.0
+  default-extensions:  StrictData
+                     , NoImplicitPrelude
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N -Wall
   default-language:    Haskell2010
 

--- a/unsafe/src/Yaya/Unsafe/Fold.hs
+++ b/unsafe/src/Yaya/Unsafe/Fold.hs
@@ -2,12 +2,36 @@
 --   laziness) can lead to non-termination.
 module Yaya.Unsafe.Fold where
 
-import Control.Arrow
-import Control.Comonad
-import Control.Lens
-import Control.Monad
-import Data.Functor.Compose
+import Control.Applicative (Applicative (..))
+import Control.Category (Category (..))
+import Control.Comonad (Comonad (..))
+import Control.Lens (Prism', matching, prism, review, (&))
+import Control.Monad (Monad, (<=<))
+import Data.Bifunctor (Bifunctor (..))
+import Data.Functor (Functor (..))
+import Data.Functor.Compose (Compose (..))
+import Data.Traversable (Traversable (..))
 import Yaya.Fold
+  ( Algebra,
+    AlgebraM,
+    Coalgebra,
+    CoalgebraM,
+    CoalgebraPrism,
+    Corecursive (..),
+    DistributiveLaw,
+    GAlgebra,
+    GAlgebraM,
+    GCoalgebra,
+    GCoalgebraM,
+    Projectable (..),
+    Recursive (..),
+    Steppable (..),
+    lowerAlgebra,
+    lowerAlgebraM,
+    lowerCoalgebra,
+    lowerCoalgebraM,
+  )
+import Yaya.Pattern (Maybe, Pair, maybe, uncurry)
 
 -- | This can’t be implemented in a total fashion. There is a _similar_ approach
 --   that can be total – with `ψ :: CoalgebraM (->) m f a`, `ana (Compose . ψ)`
@@ -63,7 +87,7 @@ ghyloM w n φ ψ =
 stream' ::
   (Projectable (->) t f, Steppable (->) u g, Functor g) =>
   CoalgebraM (->) Maybe g b ->
-  (b -> ((b -> b, t) -> u) -> f t -> u) ->
+  (b -> (Pair (b -> b) t -> u) -> f t -> u) ->
   b ->
   t ->
   u
@@ -83,7 +107,7 @@ stream' ψ f = go
 streamAna ::
   (Projectable (->) t f, Steppable (->) u g, Functor g) =>
   CoalgebraM (->) Maybe g b ->
-  AlgebraM (->) ((,) (b -> b)) f t ->
+  AlgebraM (->) (Pair (b -> b)) f t ->
   b ->
   t ->
   u
@@ -99,7 +123,7 @@ streamGApo ::
   (Projectable (->) t f, Steppable (->) u g, Corecursive (->) u g, Functor g) =>
   Coalgebra (->) g b ->
   CoalgebraM (->) Maybe g b ->
-  (f t -> Maybe (b -> b, t)) ->
+  (f t -> Maybe (Pair (b -> b) t)) ->
   b ->
   t ->
   u

--- a/unsafe/src/Yaya/Unsafe/Fold/Instances.hs
+++ b/unsafe/src/Yaya/Unsafe/Fold/Instances.hs
@@ -11,14 +11,30 @@
 --   to terminate.
 module Yaya.Unsafe.Fold.Instances where
 
-import Control.Comonad.Cofree
-import Control.Comonad.Env
-import Control.Monad.Trans.Free
-import Data.Functor.Classes
-import Data.List.NonEmpty
+import Control.Category (Category (..))
+import Control.Comonad.Cofree (Cofree)
+import Control.Comonad.Env (EnvT)
+import Control.Monad.Trans.Free (Free, FreeF (..), free)
+import Data.Eq (Eq (..))
+import Data.Foldable (Foldable)
+import Data.Function (flip)
+import Data.Functor (Functor, (<$>))
+import Data.Functor.Classes (Eq1, Show1)
+import Data.List.NonEmpty (NonEmpty)
+import Text.Show (Show (..))
 import Yaya.Fold
-import Yaya.Fold.Native
-import Yaya.Pattern
+  ( Corecursive (..),
+    DistributiveLaw,
+    Mu,
+    Nu,
+    Projectable (..),
+    Recursive (..),
+    Steppable (..),
+    recursiveEq,
+    recursiveShowsPrec,
+  )
+import Yaya.Fold.Native (Fix)
+import Yaya.Pattern (AndMaybe, XNor)
 import qualified Yaya.Unsafe.Fold as Unsafe
 
 instance Functor f => Recursive (->) (Fix f) f where

--- a/unsafe/yaya-unsafe.cabal
+++ b/unsafe/yaya-unsafe.cabal
@@ -41,7 +41,6 @@ library
   build-depends:       base >= 4.7 && < 5
                      , bifunctors
                      , comonad
-                     , either
                      , free
                      , lens
                      , yaya >= 0.3.0
@@ -55,7 +54,7 @@ library
                      , RankNTypes
                      , ScopedTypeVariables
                      , StrictData
-                     , TupleSections
+                     , NoImplicitPrelude
   default-language:    Haskell2010
 
 source-repository head


### PR DESCRIPTION
- use `StrictData` consistently
- enable `NoImplicitPrelude` to avoid getting lazy functors
- make all imports explicit to avoid lazy functors
- depend on `strict` library for strict functors