### PR TITLE
Widen Hedgehog dependency range

### DIFF
--- a/hedgehog/docs/license-report.md
+++ b/hedgehog/docs/license-report.md
@@ -10,7 +10,7 @@ Bold-faced **`package-name`**s denote standard libraries bundled with `ghc-9.10.
 | --- | --- | --- | --- | --- |
 | **`base`** | [`4.20.0.0`](http://hackage.haskell.org/package/base-4.20.0.0) | [`BSD-3-Clause`](http://hackage.haskell.org/package/base-4.20.0.0/src/LICENSE) | Core data structures and operations | *(core library)* |
 | `deriving-compat` | [`0.6.7`](http://hackage.haskell.org/package/deriving-compat-0.6.7) | [`BSD-3-Clause`](http://hackage.haskell.org/package/deriving-compat-0.6.7/src/LICENSE) | Backports of GHC deriving extensions |  |
-| `hedgehog` | [`1.4`](http://hackage.haskell.org/package/hedgehog-1.4) | [`BSD-3-Clause`](http://hackage.haskell.org/package/hedgehog-1.4/src/LICENSE) | Release with confidence. |  |
+| `hedgehog` | [`1.5`](http://hackage.haskell.org/package/hedgehog-1.5) | [`BSD-3-Clause`](http://hackage.haskell.org/package/hedgehog-1.5/src/LICENSE) | Release with confidence. |  |
 | `yaya` | [`0.6.2.2`](http://hackage.haskell.org/package/yaya-0.6.2.2) | [`AGPL-3.0-or-later`](http://hackage.haskell.org/package/yaya-0.6.2.2/src/LICENSE) | Total recursion schemes. |  |
 
 ## Indirect transitive dependencies

--- a/hedgehog/yaya-hedgehog.cabal
+++ b/hedgehog/yaya-hedgehog.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name: yaya-hedgehog
-version: 0.3.0.3
+version: 0.3.0.4
 synopsis: Hedgehog testing support for the Yaya recursion scheme library.
 description: If you use Yaya in your own code and have tests written
              using Hedgehog, then this library will help you with
@@ -167,7 +167,7 @@ library
     src
   build-depends:
     deriving-compat ^>= {0.5.9, 0.6},
-    hedgehog ^>= {1.0, 1.1, 1.2, 1.4},
+    hedgehog ^>= {1.0, 1.1, 1.2, 1.4, 1.5},
     yaya ^>= {0.5.1, 0.6.0},
   exposed-modules:
     Yaya.Hedgehog
@@ -219,7 +219,7 @@ test-suite yaya
     Test.Retrofit
   build-depends:
     deriving-compat ^>= {0.5.9, 0.6},
-    hedgehog ^>= {1.0, 1.1, 1.2, 1.4},
+    hedgehog ^>= {1.0, 1.1, 1.2, 1.4, 1.5},
     yaya ^>= {0.5.1, 0.6.0},
     yaya-hedgehog,
   ghc-options:

--- a/unsafe/yaya-unsafe.cabal
+++ b/unsafe/yaya-unsafe.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name: yaya-unsafe
-version: 0.4.1.2
+version: 0.4.1.3
 synopsis: Non-total extensions to the Yaya recursion scheme library.
 description: Yaya is designed as a _total_ library. However, it is often
              expedient to use partial operations in some cases, and this package
@@ -221,7 +221,7 @@ test-suite yaya-unsafe
   other-modules:
     Test.Fold
   build-depends:
-    hedgehog ^>= {1.0, 1.1, 1.2, 1.4},
+    hedgehog ^>= {1.0, 1.1, 1.2, 1.4, 1.5},
     yaya ^>= {0.5.1, 0.6.0},
     yaya-hedgehog ^>= {0.2.1, 0.3.0},
     yaya-unsafe,


### PR DESCRIPTION
This is failing in Nixpkgs, because the LTS upgrade in NixOS/nixpkgs#371032 is causing it to select a version of Hedgehog Yaya previously excluded.