### PR TITLE
Trivial cleanup

### DIFF
--- a/containers/src/Yaya/Containers/Pattern/IntMap.hs
+++ b/containers/src/Yaya/Containers/Pattern/IntMap.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE Safe #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
@@ -7,53 +6,50 @@ module Yaya.Containers.Pattern.IntMap
   )
 where
 
-import "base" Control.Applicative (Alternative ((<|>)), Applicative ((<*>)), (*>))
-import "base" Control.Category (Category ((.)))
+import "base" Control.Applicative ((*>), (<*>), (<|>))
+import "base" Control.Category ((.))
 import "base" Data.Bool (Bool (False, True), (&&))
-import "base" Data.Eq (Eq ((==)))
+import "base" Data.Eq (Eq, (==))
 import "base" Data.Foldable (Foldable)
 import "base" Data.Function (($))
-import "base" Data.Functor (Functor (fmap), (<$), (<$>))
-import "base" Data.Ord (Ord (compare, (<=)), Ordering (EQ, GT, LT))
+import "base" Data.Functor (Functor, fmap, (<$), (<$>))
+import "base" Data.Functor.Classes
+  ( Eq1,
+    Eq2,
+    Ord1,
+    Ord2,
+    Read1,
+    Read2,
+    Show1,
+    Show2,
+    liftCompare,
+    liftCompare2,
+    liftEq,
+    liftEq2,
+    liftReadPrec,
+    liftReadPrec2,
+    liftShowsPrec,
+    liftShowsPrec2,
+  )
+import "base" Data.Ord (Ord, Ordering (EQ, GT, LT), compare, (<=))
 import "base" Data.Semigroup ((<>))
 import "base" Data.Traversable (Traversable)
 import qualified "base" Data.Tuple as Tuple
 import "base" GHC.Generics (Generic, Generic1)
-import "base" GHC.Read (Read (readListPrec, readPrec), expectP, parens)
+import "base" GHC.Read (Read, expectP, parens, readListPrec, readPrec)
 import "base" Text.ParserCombinators.ReadPrec (prec, step)
 import qualified "base" Text.Read.Lex as Lex
+import "base" Text.Show (Show, showList, showParen, showString, showsPrec)
 import qualified "containers" Data.IntMap.Internal as IntMap
 import "yaya" Yaya.Fold
-  ( Projectable (project),
-    Recursive (cata),
-    Steppable (embed),
+  ( Projectable,
+    Recursive,
+    Steppable,
+    cata,
+    embed,
+    project,
   )
-import "base" Prelude (Num ((+)))
-#if MIN_VERSION_base(4, 18, 0)
-import "base" Data.Functor.Classes
-  ( Eq1,
-    Eq2 (liftEq2),
-    Ord2 (liftCompare2),
-    Ord1,
-    Read1 (liftReadPrec),
-    Read2 (liftReadPrec2),
-    Show1,
-    Show2 (liftShowsPrec2),
-  )
-import "base" Text.Show (Show (showsPrec), showParen, showString)
-#else
-import "base" Data.Functor.Classes
-  ( Eq1 (liftEq),
-    Eq2 (liftEq2),
-    Ord1 (liftCompare),
-    Ord2 (liftCompare2),
-    Read1 (liftReadPrec),
-    Read2 (liftReadPrec2),
-    Show1 (liftShowsPrec),
-    Show2 (liftShowsPrec2),
-  )
-import "base" Text.Show (Show (showList, showsPrec), showParen, showString)
-#endif
+import "base" Prelude ((+))
 
 data IntMapF a r
   = NilF
@@ -85,12 +81,8 @@ instance Steppable (->) (IntMap.IntMap a) (IntMapF a) where
   embed (TipF key a) = IntMap.Tip key a
   embed (BinF prefix mask l r) = IntMap.Bin prefix mask l r
 
-#if MIN_VERSION_base(4, 18, 0)
-instance (Eq a) => Eq1 (IntMapF a)
-#else
 instance (Eq a) => Eq1 (IntMapF a) where
   liftEq = liftEq2 (==)
-#endif
 
 instance Eq2 IntMapF where
   liftEq2 f g = Tuple.curry $ \case
@@ -100,12 +92,8 @@ instance Eq2 IntMapF where
       prefix == prefix' && mask == mask' && g l l' && g r r'
     (_, _) -> False
 
-#if MIN_VERSION_base(4, 18, 0)
-instance (Ord a) => Ord1 (IntMapF a)
-#else
 instance (Ord a) => Ord1 (IntMapF a) where
   liftCompare = liftCompare2 compare
-#endif
 
 instance Ord2 IntMapF where
   liftCompare2 f g = Tuple.curry $ \case
@@ -139,12 +127,8 @@ instance Read2 IntMapF where
                      <*> step readPrecR
                  )
 
-#if MIN_VERSION_base(4, 18, 0)
-instance (Show a) => Show1 (IntMapF a)
-#else
 instance (Show a) => Show1 (IntMapF a) where
   liftShowsPrec = liftShowsPrec2 showsPrec showList
-#endif
 
 instance Show2 IntMapF where
   liftShowsPrec2 showsPrecA _ showsPrecR _ p =

--- a/containers/src/Yaya/Containers/Pattern/IntSet.hs
+++ b/containers/src/Yaya/Containers/Pattern/IntSet.hs
@@ -6,39 +6,42 @@ module Yaya.Containers.Pattern.IntSet
   )
 where
 
-import "base" Control.Applicative
-  ( Alternative ((<|>)),
-    Applicative ((<*>)),
-    (*>),
-  )
-import "base" Control.Category (Category ((.)))
+import "base" Control.Applicative ((*>), (<*>), (<|>))
+import "base" Control.Category ((.))
 import "base" Data.Bool (Bool (False, True), (&&))
-import "base" Data.Eq (Eq ((==)))
+import "base" Data.Eq (Eq, (==))
 import "base" Data.Foldable (Foldable)
 import "base" Data.Function (($))
-import "base" Data.Functor (Functor (fmap), (<$), (<$>))
+import "base" Data.Functor (Functor, fmap, (<$), (<$>))
 import "base" Data.Functor.Classes
-  ( Eq1 (liftEq),
-    Ord1 (liftCompare),
-    Read1 (liftReadPrec),
-    Show1 (liftShowsPrec),
+  ( Eq1,
+    Ord1,
+    Read1,
+    Show1,
+    liftCompare,
+    liftEq,
+    liftReadPrec,
+    liftShowsPrec,
   )
-import "base" Data.Ord (Ord (compare, (<=)), Ordering (EQ, GT, LT))
+import "base" Data.Ord (Ord, Ordering (EQ, GT, LT), compare, (<=))
 import "base" Data.Semigroup ((<>))
 import "base" Data.Traversable (Traversable)
 import qualified "base" Data.Tuple as Tuple
 import "base" GHC.Generics (Generic, Generic1)
-import "base" GHC.Read (Read (readPrec), expectP, parens)
+import "base" GHC.Read (Read, expectP, parens, readPrec)
 import "base" Text.ParserCombinators.ReadPrec (prec, step)
 import qualified "base" Text.Read.Lex as Lex
-import "base" Text.Show (Show (showsPrec), showParen, showString)
+import "base" Text.Show (Show, showParen, showString, showsPrec)
 import qualified "containers" Data.IntSet.Internal as IntSet
 import "yaya" Yaya.Fold
-  ( Projectable (project),
-    Recursive (cata),
-    Steppable (embed),
+  ( Projectable,
+    Recursive,
+    Steppable,
+    cata,
+    embed,
+    project,
   )
-import "base" Prelude (Num ((+)))
+import "base" Prelude ((+))
 
 data IntSetF r
   = NilF

--- a/containers/src/Yaya/Containers/Pattern/Map.hs
+++ b/containers/src/Yaya/Containers/Pattern/Map.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE Safe #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
@@ -15,69 +14,66 @@ module Yaya.Containers.Pattern.Map
   )
 where
 
-import "base" Control.Applicative
-  ( Alternative ((<|>)),
-    Applicative ((<*>)),
-    (*>),
-  )
-import "base" Control.Category (Category ((.)))
+import "base" Control.Applicative ((*>), (<*>), (<|>))
+import "base" Control.Category ((.))
 import "base" Data.Bool (Bool (False, True), (&&))
-import "base" Data.Eq (Eq ((==)))
+import "base" Data.Eq (Eq, (==))
 import "base" Data.Foldable (Foldable)
 import "base" Data.Function (($))
-import "base" Data.Functor (Functor (fmap), (<$), (<$>))
+import "base" Data.Functor (Functor, fmap, (<$), (<$>))
+import "base" Data.Functor.Classes
+  ( Eq1,
+    Eq2,
+    Ord1,
+    Ord2,
+    Read1,
+    Read2,
+    Show1,
+    Show2,
+    liftCompare,
+    liftCompare2,
+    liftEq,
+    liftEq2,
+    liftReadPrec,
+    liftReadPrec2,
+    liftShowsPrec,
+    liftShowsPrec2,
+  )
 import "base" Data.Int (Int)
-import "base" Data.Ord (Ord (compare, (<=)), Ordering (EQ, GT, LT))
+import "base" Data.Ord (Ord, Ordering (EQ, GT, LT), compare, (<=))
 import "base" Data.Semigroup ((<>))
 import "base" Data.Traversable (Traversable)
 import qualified "base" Data.Tuple as Tuple
 import "base" GHC.Generics (Generic, Generic1)
 import "base" GHC.Read (expectP)
 import "base" Text.Read
-  ( Read (readListPrec, readPrec),
+  ( Read,
     ReadPrec,
     parens,
     prec,
+    readListPrec,
+    readPrec,
     step,
   )
 import qualified "base" Text.Read.Lex as Lex
-import qualified "containers" Data.Map.Internal as Map
-import "yaya" Yaya.Fold
-  ( Projectable (project),
-    Recursive (cata),
-    Steppable (embed),
-  )
-import "base" Prelude (Num ((+)))
-#if MIN_VERSION_base(4, 18, 0)
-import "base" Data.Functor.Classes
-  ( Eq1,
-    Eq2 (liftEq2),
-    Ord1,
-    Ord2 (liftCompare2),
-    Read1 (liftReadPrec),
-    Read2 (liftReadPrec2),
-    Show1,
-    Show2 (liftShowsPrec2),
-  )
-import "base" Text.Show (Show (showsPrec), ShowS, showParen, showString)
-#else
-import "base" Data.Functor.Classes
-  ( Eq1 (liftEq),
-    Eq2 (liftEq2),
-    Ord1 (liftCompare),
-    Ord2 (liftCompare2),
-    Read1 (liftReadPrec),
-    Read2 (liftReadPrec2),
-    Show1 (liftShowsPrec),
-    Show2 (liftShowsPrec2),
-  )
 import "base" Text.Show
-  ( Show (showList, showsPrec),
+  ( Show,
     ShowS,
+    showList,
     showParen,
     showString,
+    showsPrec,
   )
-#endif
+import qualified "containers" Data.Map.Internal as Map
+import "yaya" Yaya.Fold
+  ( Projectable,
+    Recursive,
+    Steppable,
+    cata,
+    embed,
+    project,
+  )
+import "base" Prelude ((+))
 
 data MapF k v r = TipF | BinF Map.Size k ~v r r
   deriving stock
@@ -175,22 +171,14 @@ showsMapFPrec showsPrecK showsPrecV showsPrecR p =
               . showString " "
               . showsPrecR nextPrec r
 
-#if MIN_VERSION_base(4, 18, 0)
-instance (Eq k, Eq v) => Eq1 (MapF k v)
-#else
 instance (Eq k, Eq v) => Eq1 (MapF k v) where
   liftEq = liftEq2 (==)
-#endif
 
 instance (Eq k) => Eq2 (MapF k) where
   liftEq2 = eqMapF (==)
 
-#if MIN_VERSION_base(4, 18, 0)
-instance (Ord k, Ord v) => Ord1 (MapF k v)
-#else
 instance (Ord k, Ord v) => Ord1 (MapF k v) where
   liftCompare = liftCompare2 compare
-#endif
 
 instance (Ord k) => Ord2 (MapF k) where
   liftCompare2 = compareMapF compare
@@ -204,12 +192,8 @@ instance (Read k) => Read2 (MapF k) where
   liftReadPrec2 readPrecV _ readPrecR _ =
     readMapFPrec readPrec readPrecV readPrecR
 
-#if MIN_VERSION_base(4, 18, 0)
-instance (Show k, Show v) => Show1 (MapF k v)
-#else
 instance (Show k, Show v) => Show1 (MapF k v) where
   liftShowsPrec = liftShowsPrec2 showsPrec showList
-#endif
 
 instance (Show k) => Show2 (MapF k) where
   liftShowsPrec2 showsPrecV _ showsPrecR _ =

--- a/containers/src/Yaya/Containers/Pattern/Set.hs
+++ b/containers/src/Yaya/Containers/Pattern/Set.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE Safe #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
@@ -7,57 +6,50 @@ module Yaya.Containers.Pattern.Set
   )
 where
 
-import "base" Control.Applicative
-  ( Alternative ((<|>)),
-    Applicative ((<*>)),
-    (*>),
-  )
-import "base" Control.Category (Category ((.)))
+import "base" Control.Applicative ((*>), (<*>), (<|>))
+import "base" Control.Category ((.))
 import "base" Data.Bool (Bool (False, True), (&&))
-import "base" Data.Eq (Eq ((==)))
+import "base" Data.Eq (Eq, (==))
 import "base" Data.Foldable (Foldable)
 import "base" Data.Function (($))
-import "base" Data.Functor (Functor (fmap), (<$), (<$>))
-import "base" Data.Ord (Ord (compare, (<=)), Ordering (EQ, GT, LT))
+import "base" Data.Functor (Functor, fmap, (<$), (<$>))
+import "base" Data.Functor.Classes
+  ( Eq1,
+    Eq2,
+    Ord1,
+    Ord2,
+    Read1,
+    Read2,
+    Show1,
+    Show2,
+    liftCompare,
+    liftCompare2,
+    liftEq,
+    liftEq2,
+    liftReadPrec,
+    liftReadPrec2,
+    liftShowsPrec,
+    liftShowsPrec2,
+  )
+import "base" Data.Ord (Ord, Ordering (EQ, GT, LT), compare, (<=))
 import "base" Data.Semigroup ((<>))
 import "base" Data.Traversable (Traversable)
 import qualified "base" Data.Tuple as Tuple
 import "base" GHC.Generics (Generic, Generic1)
-import "base" GHC.Read (Read (readListPrec, readPrec), expectP, parens)
+import "base" GHC.Read (Read, expectP, parens, readListPrec, readPrec)
 import "base" Text.ParserCombinators.ReadPrec (prec, step)
 import qualified "base" Text.Read.Lex as Lex
+import "base" Text.Show (Show, showList, showParen, showString, showsPrec)
 import qualified "containers" Data.Set.Internal as Set
 import "yaya" Yaya.Fold
-  ( Projectable (project),
-    Recursive (cata),
-    Steppable (embed),
+  ( Projectable,
+    Recursive,
+    Steppable,
+    cata,
+    embed,
+    project,
   )
-import "base" Prelude (Num ((+)))
-#if MIN_VERSION_base(4, 18, 0)
-import "base" Data.Functor.Classes
-  ( Eq1,
-    Eq2 (liftEq2),
-    Ord1,
-    Ord2 (liftCompare2),
-    Read1 (liftReadPrec),
-    Read2 (liftReadPrec2),
-    Show1,
-    Show2 (liftShowsPrec2),
-  )
-import "base" Text.Show (Show (showsPrec), showParen, showString)
-#else
-import "base" Data.Functor.Classes
-  ( Eq1 (liftEq),
-    Eq2 (liftEq2),
-    Ord1 (liftCompare),
-    Ord2 (liftCompare2),
-    Read1 (liftReadPrec),
-    Read2 (liftReadPrec2),
-    Show1 (liftShowsPrec),
-    Show2 (liftShowsPrec2),
-  )
-import "base" Text.Show (Show (showList, showsPrec), showParen, showString)
-#endif
+import "base" Prelude ((+))
 
 data SetF a r = TipF | BinF Set.Size a r r
   deriving stock
@@ -84,12 +76,8 @@ instance Steppable (->) (Set.Set a) (SetF a) where
   embed TipF = Set.Tip
   embed (BinF size a l r) = Set.Bin size a l r
 
-#if MIN_VERSION_base(4, 18, 0)
-instance (Eq a) => Eq1 (SetF a)
-#else
 instance (Eq a) => Eq1 (SetF a) where
   liftEq = liftEq2 (==)
-#endif
 
 instance Eq2 SetF where
   liftEq2 f g = Tuple.curry $ \case
@@ -98,12 +86,8 @@ instance Eq2 SetF where
       size == size' && f a a' && g l l' && g r r'
     (_, _) -> False
 
-#if MIN_VERSION_base(4, 18, 0)
-instance (Ord a) => Ord1 (SetF a)
-#else
 instance (Ord a) => Ord1 (SetF a) where
   liftCompare = liftCompare2 compare
-#endif
 
 instance Ord2 SetF where
   liftCompare2 f g = Tuple.curry $ \case
@@ -132,12 +116,8 @@ instance Read2 SetF where
                      <*> step readPrecR
                  )
 
-#if MIN_VERSION_base(4, 18, 0)
-instance (Show a) => Show1 (SetF a)
-#else
 instance (Show a) => Show1 (SetF a) where
   liftShowsPrec = liftShowsPrec2 showsPrec showList
-#endif
 
 instance Show2 SetF where
   liftShowsPrec2 showsPrecA _ showsPrecR _ p =

--- a/containers/tests/doctests.hs
+++ b/containers/tests/doctests.hs
@@ -3,7 +3,7 @@
 module Main (main) where
 
 import "base" Data.Function (($))
-import "base" Data.Semigroup (Semigroup ((<>)))
+import "base" Data.Semigroup ((<>))
 import "base" System.IO (IO)
 import "doctest" Test.DocTest (doctest)
 import "this" Build_doctests (flags, module_sources, pkgs)

--- a/containers/yaya-containers.cabal
+++ b/containers/yaya-containers.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name: yaya-containers
-version: 0.1.2.2
+version: 0.1.2.3
 synopsis: Pattern functors and instances for types in the containers package.
 author: Greg Pfeil <greg@technomadic.org>
 maintainer: Greg Pfeil <greg@technomadic.org>

--- a/core/src/Yaya/Applied.hs
+++ b/core/src/Yaya/Applied.hs
@@ -1,4 +1,8 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE ViewPatterns #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 -- __NB__: base-4.17 moves `IsList` to its own module, which avoids the unsafety
 --         of importing "GHC.Exts". With prior versions of base, we at least
@@ -8,10 +12,6 @@
 #else
 {-# LANGUAGE Trustworthy #-}
 #endif
-{-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE ViewPatterns #-}
-{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Yaya.Applied
   ( Void,
@@ -53,35 +53,30 @@ module Yaya.Applied
   )
 where
 
-import safe "base" Control.Category (Category (id, (.)))
-import safe "base" Data.Foldable (Foldable (foldr))
+import safe "base" Control.Category (id, (.))
+import safe "base" Data.Foldable (Foldable, foldr)
 import safe "base" Data.Function (flip)
-import safe "base" Data.Functor (Functor (fmap))
-import safe "base" Data.Functor.Identity (Identity (runIdentity))
+import safe "base" Data.Functor (Functor, fmap)
+import safe "base" Data.Functor.Identity (Identity, runIdentity)
 import safe "base" Data.Int (Int)
-import safe "base" Data.Monoid (Monoid (mempty))
-import safe "base" Data.Ord (Ord (max))
-import safe "base" Data.Semigroup (Semigroup ((<>)))
-
--- See comment on @{-# LANGUAGE Safe #-}@ above.
-#if MIN_VERSION_base(4, 17, 0)
-import "base" GHC.IsList (IsList)
-import qualified "base" GHC.IsList as IsList
-#else
-import "base" GHC.Exts (IsList)
-import qualified "base" GHC.Exts as IsList
-#endif
+import safe "base" Data.Monoid (Monoid, mempty)
+import safe "base" Data.Ord (Ord, max)
+import safe "base" Data.Semigroup (Semigroup, (<>))
 import safe "base" Numeric.Natural (Natural)
 import safe "free" Control.Monad.Trans.Free (FreeF (Free, Pure))
 import safe "this" Yaya.Fold
   ( Algebra,
-    Corecursive (ana),
+    Corecursive,
     Mu,
     Nu,
-    Projectable (project),
-    Recursive (cata),
-    Steppable (embed),
+    Projectable,
+    Recursive,
+    Steppable,
+    ana,
+    cata,
     cata2,
+    embed,
+    project,
   )
 import safe "this" Yaya.Fold.Common
   ( diagonal,
@@ -107,6 +102,15 @@ import safe "this" Yaya.Pattern
   )
 import safe "base" Prelude (Integral, fromIntegral)
 
+-- See comment on @{-# LANGUAGE Safe #-}@ above.
+#if MIN_VERSION_base(4, 17, 0)
+import "base" GHC.IsList (IsList)
+import qualified "base" GHC.IsList as IsList
+#else
+import "base" GHC.Exts (IsList)
+import qualified "base" GHC.Exts as IsList
+#endif
+
 now :: (Steppable (->) t (Either a)) => a -> t
 now = embed . Left
 
@@ -116,7 +120,8 @@ runToEnd :: (Recursive (->) t (Either a)) => t -> a
 runToEnd = cata fromEither
 
 -- | Converts exceptional divergence to non-termination.
-fromMaybe :: (Steppable (->) t (Either a), Corecursive (->) t (Either a)) => Maybe a -> t
+fromMaybe ::
+  (Steppable (->) t (Either a), Corecursive (->) t (Either a)) => Maybe a -> t
 fromMaybe = maybe (ana (toRight . never) ()) now
 
 type Void = Mu Identity

--- a/core/src/Yaya/Experimental/Foldable.hs
+++ b/core/src/Yaya/Experimental/Foldable.hs
@@ -7,18 +7,19 @@
 --   As these few operations have the usual signatures, the rest of the type
 --   class can be implemented in the as in @base@.
 module Yaya.Experimental.Foldable
-  ( Listable (naturalList),
+  ( Listable,
     foldMap,
     foldl,
     foldr,
+    naturalList,
   )
 where
 
-import "base" Control.Category (Category (id, (.)))
+import "base" Control.Category (id, (.))
 import "base" Data.Function (flip)
 import "base" Data.Monoid (Monoid)
 import "free" Control.Monad.Trans.Free (Free, iter)
-import "this" Yaya.Fold (Recursive (cata))
+import "this" Yaya.Fold (Recursive, cata)
 import "this" Yaya.Fold.Common (lowerMonoid)
 import "this" Yaya.Pattern (XNor (Both, Neither))
 

--- a/core/src/Yaya/Fold.hs
+++ b/core/src/Yaya/Fold.hs
@@ -10,7 +10,7 @@ module Yaya.Fold
     Coalgebra,
     CoalgebraM,
     CoalgebraPrism,
-    Corecursive (ana),
+    Corecursive,
     DistributiveLaw,
     ElgotAlgebra,
     ElgotAlgebraM,
@@ -21,12 +21,14 @@ module Yaya.Fold
     GCoalgebraM,
     Mu (Mu),
     Nu (Nu),
-    Projectable (project),
-    Recursive (cata),
-    Steppable (embed),
+    Projectable,
+    Recursive,
+    Steppable,
+    ana,
     attributeAlgebra,
     attributeCoalgebra,
     birecursiveIso,
+    cata,
     cata2,
     colambek,
     constAna,
@@ -39,6 +41,7 @@ module Yaya.Fold
     elgotAna,
     elgotCata,
     elgotCataM,
+    embed,
     ezygoM,
     gana,
     gcata,
@@ -50,6 +53,7 @@ module Yaya.Fold
     lowerCoalgebra,
     lowerCoalgebraM,
     lowerDay,
+    project,
     recursiveCompare,
     recursiveCompare',
     recursiveEq,
@@ -68,25 +72,28 @@ module Yaya.Fold
   )
 where
 
-import "base" Control.Applicative (Applicative (pure), (*>))
-import "base" Control.Category (Category ((.)))
+import "base" Control.Applicative (Applicative, pure, (*>))
+import "base" Control.Category ((.))
 import "base" Control.Monad (Monad, join, (<=<), (=<<))
-import "base" Data.Bifunctor (Bifunctor (bimap, first, second))
+import "base" Data.Bifunctor (bimap, first, second)
 import "base" Data.Bitraversable (bisequence)
 import "base" Data.Bool (Bool)
-import "base" Data.Eq (Eq ((==)))
-import "base" Data.Foldable (Foldable (toList))
+import "base" Data.Eq (Eq, (==))
+import "base" Data.Foldable (Foldable, toList)
 import "base" Data.Function (const, flip, ($))
-import "base" Data.Functor (Functor (fmap), (<$>))
+import "base" Data.Functor (Functor, fmap, (<$>))
 import "base" Data.Functor.Classes
-  ( Eq1 (liftEq),
-    Ord1 (liftCompare),
-    Read1 (liftReadPrec),
+  ( Eq1,
+    Ord1,
+    Read1,
     Show1,
+    liftCompare,
+    liftEq,
+    liftReadPrec,
   )
 import "base" Data.Int (Int)
 import "base" Data.List.NonEmpty (NonEmpty ((:|)))
-import "base" Data.Ord (Ord (compare, (<=)), Ordering)
+import "base" Data.Ord (Ord, Ordering, compare, (<=))
 import "base" Data.String (String)
 import "base" Data.Traversable (sequenceA)
 import "base" Data.Void (Void, absurd)
@@ -94,16 +101,18 @@ import "base" GHC.Read (expectP, list)
 import "base" GHC.Show (appPrec1)
 import "base" Numeric.Natural (Natural)
 import "base" Text.Read
-  ( Read (readListPrec, readPrec),
+  ( Read,
     ReadPrec,
     parens,
     prec,
+    readListPrec,
     readListPrecDefault,
+    readPrec,
     step,
   )
 import qualified "base" Text.Read.Lex as Lex
-import "base" Text.Show (Show (showsPrec), ShowS, showParen, showString)
-import "comonad" Control.Comonad (Comonad (duplicate, extend, extract))
+import "base" Text.Show (Show, ShowS, showParen, showString, showsPrec)
+import "comonad" Control.Comonad (Comonad, duplicate, extend, extract)
 import "comonad" Control.Comonad.Trans.Env
   ( EnvT (EnvT),
     ask,
@@ -114,18 +123,21 @@ import "free" Control.Comonad.Cofree (Cofree ((:<)))
 import "free" Control.Monad.Trans.Free (Free, FreeF (Free, Pure), free, runFree)
 import "kan-extensions" Data.Functor.Day (Day (Day))
 import "lens" Control.Lens
-  ( Const (Const, getConst),
-    Identity (Identity, runIdentity),
+  ( Const (Const),
+    Identity (Identity),
     Iso',
     Prism',
-    Traversable (traverse),
+    Traversable,
+    getConst,
     iso,
     matching,
     prism,
     review,
+    runIdentity,
+    traverse,
     view,
   )
-import "strict" Data.Strict.Classes (Strict (toStrict))
+import "strict" Data.Strict.Classes (toStrict)
 import "this" Yaya.Fold.Common
   ( compareDay,
     diagonal,
@@ -133,7 +145,7 @@ import "this" Yaya.Fold.Common
     fromEither,
     showsPrecF,
   )
-import "this" Yaya.Functor (DFunctor (dmap))
+import "this" Yaya.Functor (DFunctor, dmap)
 import "this" Yaya.Pattern
   ( AndMaybe (Indeed, Only),
     Either (Left, Right),
@@ -145,7 +157,7 @@ import "this" Yaya.Pattern
     snd,
     uncurry,
   )
-import "base" Prelude (Enum (pred, succ))
+import "base" Prelude (pred, succ)
 
 -- $setup
 -- >>> :seti -XTypeApplications

--- a/core/src/Yaya/Fold/Common.hs
+++ b/core/src/Yaya/Fold/Common.hs
@@ -31,21 +31,21 @@ module Yaya.Fold.Common
   )
 where
 
-import "base" Control.Applicative (Applicative (pure))
-import "base" Control.Category (Category (id, (.)))
+import "base" Control.Applicative (pure)
+import "base" Control.Category (id, (.))
 import "base" Control.Monad (Monad, join)
 import "base" Data.Bool (Bool (False, True), (&&))
-import "base" Data.Eq (Eq ((==)))
-import "base" Data.Foldable (Foldable (foldr, toList), and, fold)
+import "base" Data.Eq ((==))
+import "base" Data.Foldable (Foldable, and, fold, foldr, toList)
 import "base" Data.Function (($), (&))
-import "base" Data.Functor (Functor (fmap), void)
-import "base" Data.Functor.Classes (Eq1 (liftEq), Show1 (liftShowsPrec))
-import "base" Data.Functor.Identity (Identity (Identity, runIdentity))
+import "base" Data.Functor (Functor, fmap, void)
+import "base" Data.Functor.Classes (Eq1, Show1, liftEq, liftShowsPrec)
+import "base" Data.Functor.Identity (Identity (Identity), runIdentity)
 import "base" Data.Int (Int)
 import "base" Data.List (zipWith)
-import "base" Data.Monoid (Monoid (mempty))
+import "base" Data.Monoid (Monoid, mempty)
 import "base" Data.Ord (Ord (max), Ordering)
-import "base" Data.Semigroup (Semigroup ((<>)))
+import "base" Data.Semigroup (Semigroup, (<>))
 import "base" GHC.Show (showList__)
 import "base" Numeric.Natural (Natural)
 import "base" Text.Show (ShowS)
@@ -62,7 +62,7 @@ import "this" Yaya.Pattern
     maybe,
     xnor,
   )
-import Prelude (Integer, Num ((*), (+), (-)))
+import Prelude (Integer, Num, (*), (+), (-))
 
 -- | Converts the free monoid (a list) into some other `Monoid`.
 lowerMonoid :: (Monoid m) => (a -> m) -> XNor a m -> m
@@ -191,7 +191,7 @@ diagonal x = x :!: x
 
 -- * sequence generators
 
---
+-- $sequence-generators
 --   These functions are defined with different type parameters in order to
 --   constrain the implementation, but to be used as coalgebras, all of the
 --   parameters need to be specialized to the same type.

--- a/core/src/Yaya/Fold/Native.hs
+++ b/core/src/Yaya/Fold/Native.hs
@@ -6,41 +6,46 @@
 --   manner.
 module Yaya.Fold.Native
   ( module Yaya.Fold.Native.Internal,
-    Fix (Fix, unFix),
+    Fix (Fix),
     distCofreeT,
+    unFix,
   )
 where
 
-import "base" Control.Category (Category ((.)))
-import "base" Data.Bifunctor (Bifunctor (bimap))
-import "base" Data.Eq (Eq ((==)))
-import "base" Data.Foldable (Foldable (toList))
+import "base" Control.Category ((.))
+import "base" Data.Bifunctor (bimap)
+import "base" Data.Eq (Eq, (==))
+import "base" Data.Foldable (Foldable, toList)
 import "base" Data.Function (($))
-import "base" Data.Functor (Functor (fmap))
+import "base" Data.Functor (Functor, fmap)
 import "base" Data.Functor.Classes (Eq1, Ord1, Read1, Show1)
 import "base" Data.List.NonEmpty (NonEmpty ((:|)))
-import "base" Data.Ord (Ord (compare))
+import "base" Data.Ord (Ord, compare)
 import "base" Numeric.Natural (Natural)
-import "base" Text.Read (Read (readListPrec, readPrec), readListPrecDefault)
-import "base" Text.Show (Show (showsPrec))
-import "comonad" Control.Comonad (Comonad (extract))
+import "base" Text.Read (Read, readListPrec, readListPrecDefault, readPrec)
+import "base" Text.Show (Show, showsPrec)
+import "comonad" Control.Comonad (extract)
 import "comonad" Control.Comonad.Trans.Env (EnvT (EnvT), runEnvT)
 import "free" Control.Comonad.Cofree (Cofree ((:<)), unwrap)
 import "free" Control.Monad.Trans.Free (Free, FreeF (Free, Pure), free)
-import "strict" Data.Strict.Classes (Strict (toStrict))
+import "strict" Data.Strict.Classes (toStrict)
 import "this" Yaya.Fold
-  ( Corecursive (ana),
+  ( Corecursive,
     DistributiveLaw,
-    Projectable (project),
-    Recursive (cata),
-    Steppable (embed),
+    Projectable,
+    Recursive,
+    Steppable,
+    ana,
+    cata,
+    embed,
+    project,
     recursiveCompare,
     recursiveEq,
     recursiveShowsPrec,
     steppableReadPrec,
   )
 import "this" Yaya.Fold.Common (diagonal)
-import "this" Yaya.Fold.Native.Internal (Cofix (unCofix))
+import "this" Yaya.Fold.Native.Internal (Cofix, unCofix)
 import "this" Yaya.Pattern
   ( AndMaybe (Indeed, Only),
     Maybe,

--- a/core/src/Yaya/Fold/Native/Internal.hs
+++ b/core/src/Yaya/Fold/Native/Internal.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE Safe #-}
--- NB: We disable @StrictData@ here in order for `Cofix` to be lazy. I don’t
---     think there is any way to explicitly add @~@ patterns that has the
---     correct semantics.
+-- __NB__: We disable @StrictData@ here in order for `Cofix` to be lazy. I don’t
+--         think there is any way to explicitly add @~@ patterns that has the
+--         correct semantics.
 {-# LANGUAGE NoStrictData #-}
 {-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
 
@@ -12,14 +12,17 @@ module Yaya.Fold.Native.Internal
   )
 where
 
-import "base" Control.Category (Category ((.)))
-import "base" Data.Functor (Functor (fmap))
+import "base" Control.Category ((.))
+import "base" Data.Functor (Functor, fmap)
 import "base" Data.Functor.Classes (Read1)
-import "base" Text.Read (Read (readListPrec, readPrec), readListPrecDefault)
+import "base" Text.Read (Read, readListPrec, readListPrecDefault, readPrec)
 import "this" Yaya.Fold
-  ( Corecursive (ana),
-    Projectable (project),
-    Steppable (embed),
+  ( Corecursive,
+    Projectable,
+    Steppable,
+    ana,
+    embed,
+    project,
     steppableReadPrec,
   )
 

--- a/core/src/Yaya/Functor.hs
+++ b/core/src/Yaya/Functor.hs
@@ -3,16 +3,18 @@
 -- | This should probably be a separate library, but it provides a number of
 --   functor type classes between various categories.
 module Yaya.Functor
-  ( DFunctor (dmap),
-    HFunctor (hmap),
+  ( DFunctor,
+    HFunctor,
+    dmap,
     firstMap,
+    hmap,
   )
 where
 
-import "base" Control.Category (Category ((.)))
+import "base" Control.Category ((.))
 import "base" Data.Bifunctor (Bifunctor, first)
 import "base" Data.Function (($))
-import "base" Data.Functor (Functor (fmap))
+import "base" Data.Functor (Functor, fmap)
 import "base" Data.Functor.Compose (Compose (Compose))
 import "base" Data.Functor.Product (Product (Pair))
 import "base" Data.Kind (Type)

--- a/core/src/Yaya/Pattern.hs
+++ b/core/src/Yaya/Pattern.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE Safe #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
@@ -18,26 +17,49 @@ module Yaya.Pattern
 where
 
 import "base" Control.Applicative
-  ( Alternative ((<|>)),
-    Applicative (liftA2, pure, (<*>)),
+  ( Applicative,
+    liftA2,
+    pure,
     (*>),
+    (<*>),
+    (<|>),
   )
-import "base" Control.Category (Category ((.)))
-import "base" Control.Monad (Monad ((>>=)))
-import "base" Data.Bifunctor (Bifunctor (bimap))
+import "base" Control.Category ((.))
+import "base" Control.Monad (Monad, (>>=))
+import "base" Data.Bifunctor (Bifunctor, bimap)
 import "base" Data.Bool (Bool (False, True), (&&))
+import "base" Data.Eq (Eq, (==))
 import "base" Data.Foldable (Foldable)
 import "base" Data.Function (($))
 import "base" Data.Functor (Functor, (<$), (<$>))
-import "base" Data.Ord (Ord (compare, (<=)), Ordering (EQ, GT, LT))
+import "base" Data.Functor.Classes
+  ( Eq1,
+    Eq2,
+    Ord1,
+    Ord2,
+    Read1,
+    Read2,
+    Show1,
+    Show2,
+    liftCompare,
+    liftCompare2,
+    liftEq,
+    liftEq2,
+    liftReadPrec,
+    liftReadPrec2,
+    liftShowsPrec,
+    liftShowsPrec2,
+  )
+import "base" Data.Ord (Ord, Ordering (EQ, GT, LT), compare, (<=))
 import "base" Data.Semigroup ((<>))
 import "base" Data.Traversable (Traversable)
 import qualified "base" Data.Tuple as Tuple
 import "base" GHC.Generics (Generic, Generic1)
 import "base" GHC.Read (expectP)
-import "base" Text.Read (Read (readListPrec, readPrec), parens, prec, step)
+import "base" Text.Read (Read, parens, prec, readListPrec, readPrec, step)
 import qualified "base" Text.Read.Lex as Lex
-import "comonad" Control.Comonad (Comonad (duplicate, extract))
+import "base" Text.Show (Show, showList, showParen, showString, showsPrec)
+import "comonad" Control.Comonad (Comonad, duplicate, extract)
 import "strict" Data.Strict.Either
   ( Either (Left, Right),
     either,
@@ -72,34 +94,7 @@ import "strict" Data.Strict.Tuple
     zip,
     (:!:),
   )
-import "base" Prelude (Num ((+)))
-#if MIN_VERSION_base(4, 18, 0)
-import "base" Data.Eq (Eq)
-import "base" Data.Functor.Classes
-  ( Eq1,
-    Eq2 (liftEq2),
-    Ord1 (liftCompare),
-    Ord2 (liftCompare2),
-    Read1 (liftReadPrec),
-    Read2 (liftReadPrec2),
-    Show1,
-    Show2 (liftShowsPrec2),
-  )
-import "base" Text.Show (Show, showParen, showString)
-#else
-import "base" Data.Eq (Eq ((==)))
-import "base" Data.Functor.Classes
-  ( Eq1 (liftEq),
-    Eq2 (liftEq2),
-    Ord1 (liftCompare),
-    Ord2 (liftCompare2),
-    Read1 (liftReadPrec),
-    Read2 (liftReadPrec2),
-    Show1 (liftShowsPrec),
-    Show2 (liftShowsPrec2),
-  )
-import "base" Text.Show (Show (showList, showsPrec), showParen, showString)
-#endif
+import "base" Prelude ((+))
 
 -- | Isomorphic to @'Maybe` (a, b)@, it’s also the pattern functor for lists.
 data XNor a b = Neither | Both ~a b
@@ -124,12 +119,8 @@ xnor neither both = \case
   Neither -> neither
   Both x y -> both x y
 
-#if MIN_VERSION_base(4, 18, 0)
-instance (Eq a) => Eq1 (XNor a)
-#else
 instance (Eq a) => Eq1 (XNor a) where
   liftEq = liftEq2 (==)
-#endif
 
 instance Eq2 XNor where
   liftEq2 f g = Tuple.curry $ \case
@@ -137,12 +128,8 @@ instance Eq2 XNor where
     (Both x y, Both x' y') -> f x x' && g y y'
     (_, _) -> False
 
-#if MIN_VERSION_base(4, 18, 0)
-instance (Ord a) => Ord1 (XNor a)
-#else
 instance (Ord a) => Ord1 (XNor a) where
   liftCompare = liftCompare2 compare
-#endif
 
 instance Ord2 XNor where
   liftCompare2 f g = Tuple.curry $ \case
@@ -159,18 +146,15 @@ instance (Read a) => Read1 (XNor a) where
 instance Read2 XNor where
   liftReadPrec2 readPrecX _ readPrecY _ =
     let appPrec = 10
-     in parens . prec appPrec $
-          Neither
+     in parens
+          . prec appPrec
+          $ Neither
             <$ expectP (Lex.Ident "Neither")
             <|> expectP (Lex.Ident "Both")
               *> (Both <$> step readPrecX <*> step readPrecY)
 
-#if MIN_VERSION_base(4, 18, 0)
-instance (Show a) => Show1 (XNor a)
-#else
 instance (Show a) => Show1 (XNor a) where
   liftShowsPrec = liftShowsPrec2 showsPrec showList
-#endif
 
 instance Show2 XNor where
   liftShowsPrec2 showsPrecX _ showsPrecY _ p =
@@ -213,12 +197,8 @@ andMaybe only indeed = \case
   Only a -> only a
   Indeed a b -> indeed a b
 
-#if MIN_VERSION_base(4, 18, 0)
-instance (Eq a) => Eq1 (AndMaybe a)
-#else
 instance (Eq a) => Eq1 (AndMaybe a) where
   liftEq = liftEq2 (==)
-#endif
 
 instance Eq2 AndMaybe where
   liftEq2 f g = Tuple.curry $ \case
@@ -233,12 +213,8 @@ instance Eq2 AndMaybe where
 instance (Ord a, Ord b) => Ord (AndMaybe a b) where
   compare = liftCompare compare
 
-#if MIN_VERSION_base(4, 18, 0)
-instance (Ord a) => Ord1 (AndMaybe a)
-#else
 instance (Ord a) => Ord1 (AndMaybe a) where
   liftCompare = liftCompare2 compare
-#endif
 
 instance Ord2 AndMaybe where
   liftCompare2 f g = Tuple.curry $ \case
@@ -255,18 +231,15 @@ instance (Read a) => Read1 (AndMaybe a) where
 instance Read2 AndMaybe where
   liftReadPrec2 readPrecX _ readPrecY _ =
     let appPrec = 10
-     in parens . prec appPrec $
-          expectP (Lex.Ident "Only")
+     in parens
+          . prec appPrec
+          $ expectP (Lex.Ident "Only")
             *> (Only <$> step readPrecX)
             <|> expectP (Lex.Ident "Indeed")
               *> (Indeed <$> step readPrecX <*> step readPrecY)
 
-#if MIN_VERSION_base(4, 18, 0)
-instance (Show a) => Show1 (AndMaybe a)
-#else
 instance (Show a) => Show1 (AndMaybe a) where
   liftShowsPrec = liftShowsPrec2 showsPrec showList
-#endif
 
 instance Show2 AndMaybe where
   liftShowsPrec2 showsPrecX _ showsPrecY _ p =

--- a/core/src/Yaya/Retrofit.hs
+++ b/core/src/Yaya/Retrofit.hs
@@ -29,40 +29,38 @@
 --   disappear.
 module Yaya.Retrofit
   ( module Yaya.Fold,
-    PatternFunctorRules
-      ( PatternFunctorRules,
-        patternCon,
-        patternField,
-        patternType
-      ),
+    PatternFunctorRules (PatternFunctorRules),
     defaultRules,
     extractPatternFunctor,
+    patternCon,
+    patternField,
+    patternType,
   )
 where
 
 -- NB: This module does not use the strict library, because its use of `Either`,
 --    `Maybe`, etc. is tied to template-haskell and does not involve recursion
 --     schemes.
-import safe "base" Control.Applicative (Applicative (pure))
-import safe "base" Control.Category (Category (id, (.)))
+import safe "base" Control.Applicative (Applicative, pure)
+import safe "base" Control.Category (id, (.))
 import safe "base" Control.Monad ((<=<))
-import safe "base" Control.Monad.Fail (MonadFail (fail))
-import safe "base" Data.Bifunctor (Bifunctor (bimap))
+import safe "base" Control.Monad.Fail (fail)
+import safe "base" Data.Bifunctor (bimap)
 import safe "base" Data.Bool (Bool, otherwise, (&&))
 import safe "base" Data.Either (Either (Left), either)
-import safe "base" Data.Eq (Eq ((==)))
-import safe "base" Data.Foldable (Foldable (foldl, length, null))
+import safe "base" Data.Eq ((==))
+import safe "base" Data.Foldable (Foldable, foldl, length, null)
 import safe "base" Data.Function (const, flip, ($))
-import safe "base" Data.Functor (Functor (fmap), (<$>))
-import safe "base" Data.Functor.Identity (Identity (Identity, runIdentity))
+import safe "base" Data.Functor (Functor, fmap, (<$>))
+import safe "base" Data.Functor.Identity (Identity (Identity), runIdentity)
 import safe "base" Data.List (all, zip, zip3)
 import safe "base" Data.List.NonEmpty (NonEmpty)
 import safe "base" Data.Maybe (Maybe (Just, Nothing), maybe)
-import safe "base" Data.Semigroup (Semigroup ((<>)))
+import safe "base" Data.Semigroup ((<>))
 import safe "base" Data.String (String)
-import safe "base" Data.Traversable (Traversable (traverse))
+import safe "base" Data.Traversable (Traversable, traverse)
 import safe "base" Text.Read.Lex (isSymbolChar)
-import safe "base" Text.Show (Show (show))
+import safe "base" Text.Show (Show, show)
 import safe "either" Data.Either.Validation
   ( Validation (Failure, Success),
     validationToEither,
@@ -70,10 +68,14 @@ import safe "either" Data.Either.Validation
 import safe qualified "template-haskell" Language.Haskell.TH as TH
 import safe qualified "th-abstraction" Language.Haskell.TH.Datatype as TH.Abs
 import safe "this" Yaya.Fold
-  ( Corecursive (ana),
-    Projectable (project),
-    Recursive (cata),
-    Steppable (embed),
+  ( Corecursive,
+    Projectable,
+    Recursive,
+    Steppable,
+    ana,
+    cata,
+    embed,
+    project,
     recursiveCompare,
     recursiveCompare',
     recursiveEq,
@@ -102,7 +104,8 @@ conP' n = TH.ConP n []
 conP' = TH.ConP
 #endif
 
--- | Extract a pattern functor and relevant instances from a simply recursive type.
+-- | Extract a pattern functor and relevant instances from a simply recursive
+--   type.
 --
 -- /e.g./
 --
@@ -147,9 +150,12 @@ conP' = TH.ConP
 -- - `extractPatternFunctor` works properly only with ADTs.
 --   Existentials and GADTs aren't supported,
 --   as we don't try to do better than
---   <https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/glasgow_exts.html#deriving-functor-instances GHC's DeriveFunctor>.
--- - we always generate both `Recursive` and `Corecursive` instances, but one of these is always unsafe.
---   In future, we should check the strictness of the recursive parameter and generate only the appropriate one (unless overridden by a rule).
+--   <https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/glasgow_exts.html#deriving-functor-instances
+--   GHC's DeriveFunctor>.
+-- - we always generate both `Recursive` and `Corecursive` instances, but one of
+--   these is always unsafe. In future, we should check the strictness of the
+--   recursive parameter and generate only the appropriate one (unless
+--   overridden by a rule).
 extractPatternFunctor :: PatternFunctorRules -> TH.Name -> TH.Q [TH.Dec]
 extractPatternFunctor rules =
   either (fail . displayUnsupportedDatatype) id . makePrimForDI rules
@@ -162,7 +168,8 @@ data PatternFunctorRules = PatternFunctorRules
     patternField :: TH.Name -> TH.Name
   }
 
--- | Default 'PatternFunctorRules': append @F@ or @$@ to data type, constructors and field names.
+-- | Default 'PatternFunctorRules': append @F@ or @$@ to data type, constructors
+--   and field names.
 defaultRules :: PatternFunctorRules
 defaultRules =
   PatternFunctorRules
@@ -349,7 +356,8 @@ mkMorphism nFrom nTo =
 -------------------------------------------------------------------------------
 
 conNameTraversal :: Traversal' TH.Abs.ConstructorInfo TH.Name
-conNameTraversal = lens TH.Abs.constructorName (\s v -> s {TH.Abs.constructorName = v})
+conNameTraversal =
+  lens TH.Abs.constructorName (\s v -> s {TH.Abs.constructorName = v})
 
 conFieldNameTraversal :: Traversal' TH.Abs.ConstructorInfo TH.Name
 conFieldNameTraversal =

--- a/core/src/Yaya/Zoo.hs
+++ b/core/src/Yaya/Zoo.hs
@@ -9,7 +9,7 @@ module Yaya.Zoo
     List,
     Nat,
     NonEmptyList,
-    Partial (Partial, fromPartial),
+    Partial (Partial),
     Stream,
     apo,
     cataM,
@@ -17,6 +17,7 @@ module Yaya.Zoo
     comap,
     comutu,
     contramap,
+    fromPartial,
     gapo,
     gmutu,
     histo,
@@ -31,36 +32,40 @@ module Yaya.Zoo
   )
 where
 
-import "base" Control.Applicative (Applicative (pure, (<*>)))
-import "base" Control.Category (Category (id, (.)))
-import "base" Control.Monad (Monad ((>>=)), (<=<))
-import "base" Data.Bifunctor (Bifunctor (bimap, first))
-import "base" Data.Bitraversable (Bitraversable (bitraverse), bisequence)
+import "base" Control.Applicative (Applicative, pure, (<*>))
+import "base" Control.Category (id, (.))
+import "base" Control.Monad (Monad, (<=<), (>>=))
+import "base" Data.Bifunctor (Bifunctor, bimap, first)
+import "base" Data.Bitraversable (Bitraversable, bisequence, bitraverse)
 import "base" Data.Function (flip, ($))
-import "base" Data.Functor (Functor (fmap))
-import "base" Data.Traversable (Traversable (sequenceA))
-import "comonad" Control.Comonad (Comonad (duplicate, extract))
+import "base" Data.Functor (Functor, fmap)
+import "base" Data.Traversable (Traversable, sequenceA)
+import "comonad" Control.Comonad (Comonad, duplicate, extract)
 import "comonad" Control.Comonad.Env (EnvT (EnvT))
 import "free" Control.Comonad.Cofree (Cofree)
-import "profunctors" Data.Profunctor (Profunctor (lmap))
+import "profunctors" Data.Profunctor (Profunctor, lmap)
 import "this" Yaya.Fold
   ( Algebra,
     AlgebraM,
     Coalgebra,
-    Corecursive (ana),
+    Corecursive,
     DistributiveLaw,
     GAlgebra,
     GAlgebraM,
     GCoalgebra,
     Mu,
     Nu,
-    Projectable (project),
-    Recursive (cata),
-    Steppable (embed),
+    Projectable,
+    Recursive,
+    Steppable,
+    ana,
+    cata,
     distTuple,
     elgotAna,
+    embed,
     gana,
     gcata,
+    project,
     seqEither,
   )
 import "this" Yaya.Fold.Common (diagonal, fromEither)
@@ -258,7 +263,11 @@ type Stream a = Nu (Pair a)
 -- | A more general implementation of `fmap`, because it can also work to, from,
 --   or within monomorphic structures, obviating the need for classes like
 --  `Data.MonoTraversable.MonoFunctor`.
-map :: (Recursive (->) t (f a), Steppable (->) u (f b), Bifunctor f) => (a -> b) -> t -> u
+map ::
+  (Recursive (->) t (f a), Steppable (->) u (f b), Bifunctor f) =>
+  (a -> b) ->
+  t ->
+  u
 map f = cata (embed . first f)
 
 -- | A version of `Yaya.Zoo.map` that applies to Corecursive structures.

--- a/core/tests/doctests.hs
+++ b/core/tests/doctests.hs
@@ -3,7 +3,7 @@
 module Main (main) where
 
 import safe "base" Data.Function (($))
-import safe "base" Data.Semigroup (Semigroup ((<>)))
+import safe "base" Data.Semigroup ((<>))
 import safe "base" System.IO (IO)
 import "doctest" Test.DocTest (doctest)
 import "this" Build_doctests (flags, module_sources, pkgs)

--- a/core/yaya.cabal
+++ b/core/yaya.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name: yaya
-version: 0.6.2.3
+version: 0.6.2.4
 synopsis: Total recursion schemes.
 description: Recursion schemes allow you to separate recursion from your
              business logic – making your own operations simpler, more modular,

--- a/hedgehog/src/Yaya/Hedgehog.hs
+++ b/hedgehog/src/Yaya/Hedgehog.hs
@@ -6,7 +6,7 @@ module Yaya.Hedgehog
   )
 where
 
-import safe "base" Control.Category (Category ((.)))
+import safe "base" Control.Category ((.))
 import safe "base" Control.Monad ((<=<))
 import safe "base" Control.Monad.IO.Class (MonadIO)
 import safe "base" Data.Function (const)

--- a/hedgehog/src/Yaya/Hedgehog/Expr.hs
+++ b/hedgehog/src/Yaya/Hedgehog/Expr.hs
@@ -14,7 +14,7 @@ module Yaya.Hedgehog.Expr
   )
 where
 
-import safe "base" Control.Applicative (Applicative ((<*>)))
+import safe "base" Control.Applicative ((<*>))
 import safe "base" Data.Eq (Eq)
 import safe "base" Data.Foldable (Foldable)
 import safe "base" Data.Functor (Functor, (<$>))

--- a/hedgehog/src/Yaya/Hedgehog/Fold.hs
+++ b/hedgehog/src/Yaya/Hedgehog/Fold.hs
@@ -15,11 +15,11 @@ module Yaya.Hedgehog.Fold
   )
 where
 
-import safe "base" Control.Category (Category ((.)))
-import safe "base" Data.Bifunctor (Bifunctor (bimap, first))
+import safe "base" Control.Category ((.))
+import safe "base" Data.Bifunctor (bimap, first)
 import safe "base" Data.Eq (Eq)
 import safe "base" Data.Function (($))
-import safe "base" Data.Functor (Functor (fmap))
+import safe "base" Data.Functor (Functor, fmap)
 import safe "base" Data.Proxy (Proxy (Proxy))
 import safe qualified "base" Data.Tuple as Tuple
 import safe "base" Data.Void (Void, absurd)
@@ -36,10 +36,14 @@ import "hedgehog" Hedgehog
   )
 import "yaya" Yaya.Fold
   ( Algebra,
-    Corecursive (ana),
-    Projectable (project),
-    Recursive (cata),
-    Steppable (embed),
+    Corecursive,
+    Projectable,
+    Recursive,
+    Steppable,
+    ana,
+    cata,
+    embed,
+    project,
   )
 import safe "yaya" Yaya.Fold.Common (diagonal)
 import safe "yaya" Yaya.Fold.Native ()

--- a/hedgehog/tests/Test/Fold.hs
+++ b/hedgehog/tests/Test/Fold.hs
@@ -4,13 +4,19 @@
 
 module Test.Fold (tests) where
 
-import safe "base" Control.Category (Category (id))
+import safe "base" Control.Category (id)
 import safe "base" Control.Monad ((=<<))
 import safe "base" Data.Bool (Bool)
 import safe "base" Data.Function (($))
 import safe "base" Data.Proxy (Proxy (Proxy))
 import safe "base" System.IO (IO)
-import safe "hedgehog" Hedgehog (Property, checkParallel, discover, forAll, property)
+import safe "hedgehog" Hedgehog
+  ( Property,
+    checkParallel,
+    discover,
+    forAll,
+    property,
+  )
 import safe qualified "hedgehog" Hedgehog.Gen as Gen
 import safe "yaya" Yaya.Fold (Mu)
 import safe "yaya" Yaya.Fold.Common (size)

--- a/hedgehog/tests/Test/Fold/Common.hs
+++ b/hedgehog/tests/Test/Fold/Common.hs
@@ -4,11 +4,11 @@
 
 module Test.Fold.Common (tests) where
 
-import safe "base" Control.Category (Category ((.)))
+import safe "base" Control.Category ((.))
 import safe "base" Control.Monad ((=<<))
 import safe "base" Data.Bool (Bool)
-import safe "base" Data.Functor (Functor (fmap))
-import safe "base" Data.Ord (Ord ((<)))
+import safe "base" Data.Functor (fmap)
+import safe "base" Data.Ord ((<))
 import safe "base" System.IO (IO)
 import safe "hedgehog" Hedgehog
   ( Property,
@@ -19,11 +19,11 @@ import safe "hedgehog" Hedgehog
     property,
   )
 import safe qualified "hedgehog" Hedgehog.Gen as Gen
-import safe "yaya" Yaya.Fold (Recursive (cata), zipAlgebras)
+import safe "yaya" Yaya.Fold (cata, zipAlgebras)
 import safe "yaya" Yaya.Fold.Common (height, size)
 import safe "yaya" Yaya.Pattern (uncurry)
 import safe "yaya-hedgehog" Yaya.Hedgehog.Expr (genMuExpr)
-import safe "base" Prelude (Integral (toInteger))
+import safe "base" Prelude (toInteger)
 
 -- TODO: For some reason HLint is complaining that TemplateHaskell is unused.
 {-# HLINT ignore "Unused LANGUAGE pragma" #-}

--- a/hedgehog/tests/Test/Fold/Native.hs
+++ b/hedgehog/tests/Test/Fold/Native.hs
@@ -4,13 +4,19 @@
 
 module Test.Fold.Native (tests) where
 
-import safe "base" Control.Category (Category (id))
+import safe "base" Control.Category (id)
 import safe "base" Control.Monad ((=<<))
 import safe "base" Data.Bool (Bool)
 import safe "base" Data.Function (($))
 import safe "base" Data.Proxy (Proxy (Proxy))
 import safe "base" System.IO (IO)
-import safe "hedgehog" Hedgehog (Property, checkParallel, discover, forAll, property)
+import safe "hedgehog" Hedgehog
+  ( Property,
+    checkParallel,
+    discover,
+    forAll,
+    property,
+  )
 import safe qualified "hedgehog" Hedgehog.Gen as Gen
 import safe "yaya" Yaya.Fold.Common (size)
 import safe "yaya" Yaya.Fold.Native (Fix)

--- a/hedgehog/tests/Test/Retrofit.hs
+++ b/hedgehog/tests/Test/Retrofit.hs
@@ -6,15 +6,17 @@
 module Test.Retrofit (tests) where
 
 import safe "base" Data.Bool (Bool)
-import safe "base" Data.Eq (Eq ((==)))
+import safe "base" Data.Eq (Eq, (==))
 import safe "base" Data.Int (Int)
-import safe "base" Data.Ord (Ord (compare))
+import safe "base" Data.Ord (Ord, compare)
 import safe "base" System.IO (IO)
 import safe "base" Text.Read
-  ( Read (readListPrec, readPrec),
+  ( Read,
+    readListPrec,
     readListPrecDefault,
+    readPrec,
   )
-import safe "base" Text.Show (Show (showsPrec))
+import safe "base" Text.Show (Show, showsPrec)
 import safe "deriving-compat" Data.Eq.Deriving (deriveEq1)
 import safe "deriving-compat" Data.Ord.Deriving (deriveOrd1)
 import safe "deriving-compat" Text.Read.Deriving (deriveRead1)

--- a/hedgehog/tests/doctests.hs
+++ b/hedgehog/tests/doctests.hs
@@ -3,7 +3,7 @@
 module Main (main) where
 
 import "base" Data.Function (($))
-import "base" Data.Semigroup (Semigroup ((<>)))
+import "base" Data.Semigroup ((<>))
 import "base" System.IO (IO)
 import "doctest" Test.DocTest (doctest)
 import "this" Build_doctests (flags, module_sources, pkgs)

--- a/hedgehog/yaya-hedgehog.cabal
+++ b/hedgehog/yaya-hedgehog.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name: yaya-hedgehog
-version: 0.3.0.5
+version: 0.3.0.6
 synopsis: Hedgehog testing support for the Yaya recursion scheme library.
 description: If you use Yaya in your own code and have tests written
              using Hedgehog, then this library will help you with

--- a/quickcheck/src/Yaya/QuickCheck/Fold.hs
+++ b/quickcheck/src/Yaya/QuickCheck/Fold.hs
@@ -8,18 +8,13 @@ module Yaya.QuickCheck.Fold
 where
 
 import qualified "QuickCheck" Test.QuickCheck as QC
-import "base" Control.Applicative (Applicative (pure, (<*>)))
+import "base" Control.Applicative (pure, (<*>))
 import "base" Data.Foldable (Foldable)
 import qualified "base" Data.Foldable as Foldable
 import "base" Data.Function (flip)
 import "base" Data.Functor (Functor, (<$>))
-import "base" Data.Semigroup (Semigroup ((<>)))
-import "yaya" Yaya.Fold
-  ( Mu,
-    Nu,
-    Projectable (project),
-    Steppable (embed),
-  )
+import "base" Data.Semigroup ((<>))
+import "yaya" Yaya.Fold (Mu, Nu, Steppable, embed, project)
 import "yaya" Yaya.Fold.Native (Cofix, Fix)
 import "yaya" Yaya.Pattern (AndMaybe (Indeed, Only), XNor (Both, Neither))
 

--- a/quickcheck/tests/doctests.hs
+++ b/quickcheck/tests/doctests.hs
@@ -3,7 +3,7 @@
 module Main (main) where
 
 import "base" Data.Function (($))
-import "base" Data.Semigroup (Semigroup ((<>)))
+import "base" Data.Semigroup ((<>))
 import "base" System.IO (IO)
 import "doctest" Test.DocTest (doctest)
 import "this" Build_doctests (flags, module_sources, pkgs)

--- a/quickcheck/yaya-quickcheck.cabal
+++ b/quickcheck/yaya-quickcheck.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name: yaya-quickcheck
-version: 0.2.0.3
+version: 0.2.0.4
 synopsis: QuickCheck testing support for the Yaya recursion scheme library.
 description: If you use Yaya in your own code and have tests written using
              QuickCheck, then this library will help you with generating trees,

--- a/unsafe/src/Yaya/Unsafe/Applied.hs
+++ b/unsafe/src/Yaya/Unsafe/Applied.hs
@@ -5,7 +5,7 @@ module Yaya.Unsafe.Applied
   )
 where
 
-import "yaya" Yaya.Fold (Steppable (embed))
+import "yaya" Yaya.Fold (Steppable, embed)
 import "yaya" Yaya.Pattern (XNor)
 import "this" Yaya.Unsafe.Fold (unsafeCata)
 

--- a/unsafe/src/Yaya/Unsafe/Fold.hs
+++ b/unsafe/src/Yaya/Unsafe/Fold.hs
@@ -18,14 +18,14 @@ module Yaya.Unsafe.Fold
   )
 where
 
-import "base" Control.Applicative (Applicative (pure))
-import "base" Control.Category (Category ((.)))
+import "base" Control.Applicative (pure)
+import "base" Control.Category ((.))
 import "base" Control.Monad (Monad, (<=<))
 import "base" Data.Function (flip, ($))
-import "base" Data.Functor (Functor (fmap))
-import "base" Data.Functor.Compose (Compose (Compose, getCompose))
-import "base" Data.Traversable (Traversable (sequenceA))
-import "comonad" Control.Comonad (Comonad (extract))
+import "base" Data.Functor (Functor, fmap)
+import "base" Data.Functor.Compose (Compose (Compose), getCompose)
+import "base" Data.Traversable (Traversable, sequenceA)
+import "comonad" Control.Comonad (Comonad, extract)
 import "lens" Control.Lens (Prism', matching, prism, review)
 import "yaya" Yaya.Fold
   ( Algebra,
@@ -33,19 +33,23 @@ import "yaya" Yaya.Fold
     Coalgebra,
     CoalgebraM,
     CoalgebraPrism,
-    Corecursive (ana),
+    Corecursive,
     DistributiveLaw,
     GAlgebra,
     GAlgebraM,
     GCoalgebra,
     GCoalgebraM,
-    Projectable (project),
-    Recursive (cata),
-    Steppable (embed),
+    Projectable,
+    Recursive,
+    Steppable,
+    ana,
+    cata,
+    embed,
     lowerAlgebra,
     lowerAlgebraM,
     lowerCoalgebra,
     lowerCoalgebraM,
+    project,
   )
 import "yaya" Yaya.Pattern (Maybe, Pair, maybe, uncurry)
 

--- a/unsafe/src/Yaya/Unsafe/Fold/Instances.hs
+++ b/unsafe/src/Yaya/Unsafe/Fold/Instances.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 -- __NB__: base-4.17 moves `IsList` to its own module, which avoids the unsafety
 --         of importing "GHC.Exts". With prior versions of base, we at least
@@ -8,8 +10,6 @@
 #else
 {-# LANGUAGE Trustworthy #-}
 #endif
-{-# LANGUAGE TypeFamilies #-}
-{-# OPTIONS_GHC -Wno-orphans #-}
 
 -- | Type class instances that use direct recursion in a potentially partial
 --   way. This is separated from the rest of `Yaya.Unsafe.Fold` because you can
@@ -25,33 +25,28 @@ module Yaya.Unsafe.Fold.Instances
   )
 where
 
-import safe "base" Control.Category (Category ((.)))
-import safe "base" Data.Eq (Eq ((==)))
+import safe "base" Control.Category ((.))
+import safe "base" Data.Eq (Eq, (==))
 import safe "base" Data.Foldable (Foldable)
 import safe "base" Data.Function (flip)
 import safe "base" Data.Functor (Functor, (<$>))
 import safe "base" Data.Functor.Classes (Eq1, Ord1, Show1)
 import safe "base" Data.List.NonEmpty (NonEmpty)
-import safe "base" Data.Ord (Ord (compare))
-
--- See comment on @{-# LANGUAGE Safe #-}@ above.
-#if MIN_VERSION_base(4, 17, 0)
-import "base" GHC.IsList (IsList (Item, fromList, fromListN, toList))
-#else
-import "base" GHC.Exts (IsList (Item, fromList, fromListN, toList))
-#endif
-import safe "base" Text.Show (Show (showsPrec))
+import safe "base" Data.Ord (Ord, compare)
+import safe "base" Text.Show (Show, showsPrec)
 import safe "comonad" Control.Comonad.Env (EnvT)
 import safe "free" Control.Comonad.Cofree (Cofree)
 import safe "free" Control.Monad.Trans.Free (Free, FreeF (Free, Pure), free)
 import safe "yaya" Yaya.Fold
-  ( Corecursive (ana),
+  ( Corecursive,
     DistributiveLaw,
     Mu,
     Nu,
-    Projectable (project),
-    Recursive (cata),
-    Steppable (embed),
+    Recursive,
+    ana,
+    cata,
+    embed,
+    project,
     recursiveCompare,
     recursiveEq,
     recursiveShowsPrec,
@@ -60,6 +55,13 @@ import safe "yaya" Yaya.Fold.Native (Cofix, Fix)
 import safe "yaya" Yaya.Pattern (AndMaybe, XNor)
 import safe "this" Yaya.Unsafe.Applied (unsafeFromList)
 import safe qualified "this" Yaya.Unsafe.Fold as Unsafe
+
+-- See comment on @{-# LANGUAGE Safe #-}@ above.
+#if MIN_VERSION_base(4, 17, 0)
+import "base" GHC.IsList (IsList (Item, fromList, fromListN, toList))
+#else
+import "base" GHC.Exts (IsList (Item, fromList, fromListN, toList))
+#endif
 
 instance (Functor f) => Corecursive (->) (Fix f) f where
   ana = Unsafe.hylo embed

--- a/unsafe/tests/Test/Fold.hs
+++ b/unsafe/tests/Test/Fold.hs
@@ -5,7 +5,7 @@
 
 module Test.Fold (tests) where
 
-import safe "base" Control.Category (Category (id))
+import safe "base" Control.Category (id)
 import safe "base" Control.Monad ((=<<))
 import safe "base" Data.Bool (Bool)
 import safe "base" Data.Function (($))

--- a/unsafe/tests/doctests.hs
+++ b/unsafe/tests/doctests.hs
@@ -3,7 +3,7 @@
 module Main (main) where
 
 import "base" Data.Function (($))
-import "base" Data.Semigroup (Semigroup ((<>)))
+import "base" Data.Semigroup ((<>))
 import "base" System.IO (IO)
 import "doctest" Test.DocTest (doctest)
 import "this" Build_doctests (flags, module_sources, pkgs)

--- a/unsafe/yaya-unsafe.cabal
+++ b/unsafe/yaya-unsafe.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name: yaya-unsafe
-version: 0.4.1.4
+version: 0.4.1.5
 synopsis: Non-total extensions to the Yaya recursion scheme library.
 description: Yaya is designed as a _total_ library. However, it is often
              expedient to use partial operations in some cases, and this package


### PR DESCRIPTION
This contains some changes that have been bugging me for a while, but are just annoying enough to not get around to.

- remove `CPP` that’s only used to get default impls in some cases,
- separate field and method imports from type and class imports[^1],
- move CPP blocks to end of sections (pragmas, imports)[^2], and
- shorten long lines.

[^1]: This style of importing is slightly more robust, as it continues to work even when fields and methods are moved to top-level definitions.

[^2]: Ormolu can’t format within CPP blocks, so putting it in the middle of a section prevents automatic moving of elements from one side of the CPP to the other.