### PR TITLE
Restrict the bounds on free

### DIFF
--- a/core/yaya.cabal
+++ b/core/yaya.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name: yaya
-version: 0.6.2.3
+version: 0.6.2.4
 synopsis: Total recursion schemes.
 description: Recursion schemes allow you to separate recursion from your
              business logic – making your own operations simpler, more modular,
@@ -170,7 +170,7 @@ library
   build-depends:
     comonad ^>= 5.0.7,
     either ^>= 5,
-    free ^>= {5.1.5, 5.2},
+    free ^>= {5.1.6, 5.2},
     kan-extensions ^>= 5.2,
     -- `Control.Lens` in lens < 5 is `Unsafe`
     lens ^>= {5, 5.1, 5.2, 5.3},

--- a/unsafe/yaya-unsafe.cabal
+++ b/unsafe/yaya-unsafe.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name: yaya-unsafe
-version: 0.4.1.4
+version: 0.4.1.5
 synopsis: Non-total extensions to the Yaya recursion scheme library.
 description: Yaya is designed as a _total_ library. However, it is often
              expedient to use partial operations in some cases, and this package
@@ -172,7 +172,7 @@ library
     src
   build-depends:
     comonad ^>= 5.0.7,
-    free ^>= {5.1.5, 5.2},
+    free ^>= {5.1.6, 5.2},
     -- `Control.Lens` in lens < 5 is `Unsafe`
     lens ^>= {5, 5.1, 5.2, 5.3},
     yaya ^>= {0.5.1, 0.6.0},


### PR DESCRIPTION
free 5.1.5 isn’t `Safe`, so this ensures we use at least 5.1.6.