### PR TITLE
Add `INLINABLE` to a bunch of stuff

### DIFF
--- a/containers/yaya-containers.cabal
+++ b/containers/yaya-containers.cabal
@@ -141,8 +141,6 @@ common defaults
     base ^>= {4.13.0, 4.14.0, 4.15.0, 4.16.0, 4.17.0, 4.18.0, 4.19.0, 4.20.0, 4.21.0, 4.22.0},
   ghc-options:
     -Weverything
-    -- This one just reports unfixable things, AFAICT.
-    -Wno-all-missed-specialisations
     -- Type inference good.
     -Wno-missing-local-signatures
     -- Warns even when `Unsafe` is explicit, not inferred. See

--- a/core/src/Yaya/Fold.hs
+++ b/core/src/Yaya/Fold.hs
@@ -298,6 +298,7 @@ recursiveShowsPrec' showsFPrec = flip . cata $
   \f p ->
     showParen (appPrec1 <= p) $
       showString embedOperation . showString " " . showsFPrec f appPrec1
+{-# INLINEABLE recursiveShowsPrec' #-}
 
 -- | An implementation of `showsPrec` for any `Recursive` instance.
 #if MIN_VERSION_GLASGOW_HASKELL(8, 8, 0, 0) \
@@ -335,6 +336,7 @@ recursiveShowsPrec' showsFPrec = flip . cata $
 --         `steppableReadPrec`, which requires `Steppable` instead.
 recursiveShowsPrec :: (Recursive (->) t f, Show1 f) => Int -> t -> ShowS
 recursiveShowsPrec = recursiveShowsPrec' $ flip showsPrecF
+{-# INLINEABLE recursiveShowsPrec #-}
 
 -- | Like `steppableReadPrec`, but allows you to provide a custom display
 --   function for @f@.
@@ -374,6 +376,7 @@ newtype Mu f = Mu (forall a. Algebra (->) f a -> a)
 
 instance (Functor f) => Projectable (->) (Mu f) f where
   project = lambek
+  {-# INLINEABLE project #-}
 
 instance (Functor f) => Steppable (->) (Mu f) f where
   embed m = Mu (\f -> f (fmap (cata f) m))
@@ -386,6 +389,7 @@ instance DFunctor Mu where
 
 instance (Functor f, Foldable f, Eq1 f) => Eq (Mu f) where
   (==) = recursiveEq
+  {-# INLINEABLE (==) #-}
 
 -- | @since 0.6.1.0
 instance (Functor f, Foldable f, Ord1 f) => Ord (Mu f) where
@@ -405,9 +409,11 @@ data Nu f where Nu :: Coalgebra (->) f a -> a -> Nu f
 
 instance (Functor f) => Projectable (->) (Nu f) f where
   project (Nu f a) = Nu f <$> f a
+  {-# INLINEABLE project #-}
 
 instance (Functor f) => Steppable (->) (Nu f) f where
   embed = colambek
+  {-# INLINEABLE embed #-}
 
 instance Corecursive (->) (Nu f) f where
   ana = Nu

--- a/core/src/Yaya/Fold/Common.hs
+++ b/core/src/Yaya/Fold/Common.hs
@@ -86,6 +86,7 @@ equalDay ::
 equalDay eqF (Day f1 f2 fn) =
   eqF (void f1) (void f2)
     && and (zipWith fn (toList f1) (toList f2))
+{-# INLINEABLE equalDay #-}
 
 -- | Provides equality over arbitrary pattern functors.
 equal :: (Functor f, Foldable f, Eq1 f) => Day f f Bool -> Bool
@@ -102,6 +103,7 @@ compareDay ::
 compareDay compareF (Day f1 f2 fn) =
   compareF (void f1) (void f2)
     <> fold (zipWith fn (toList f1) (toList f2))
+{-# INLINEABLE compareDay #-}
 
 -- | Provides show over arbitrary pattern functors.
 --

--- a/core/src/Yaya/Fold/Native.hs
+++ b/core/src/Yaya/Fold/Native.hs
@@ -59,6 +59,7 @@ instance Steppable (->) (Fix f) f where
 
 instance (Functor f) => Recursive (->) (Fix f) f where
   cata ɸ = ɸ . fmap (cata ɸ) . project
+  {-# INLINEABLE cata #-}
 
 instance (Functor f, Foldable f, Eq1 f) => Eq (Fix f) where
   (==) = recursiveEq

--- a/core/src/Yaya/Fold/Native/Internal.hs
+++ b/core/src/Yaya/Fold/Native/Internal.hs
@@ -40,6 +40,7 @@ instance Steppable (->) (Cofix f) f where
 
 instance (Functor f) => Corecursive (->) (Cofix f) f where
   ana φ = embed . fmap (ana φ) . φ
+  {-# INLINEABLE ana #-}
 
 -- | @since 0.6.1.0
 instance (Read1 f) => Read (Cofix f) where

--- a/core/yaya.cabal
+++ b/core/yaya.cabal
@@ -147,8 +147,6 @@ common defaults
     base ^>= {4.13.0, 4.14.0, 4.15.0, 4.16.0, 4.17.0, 4.18.0, 4.19.0, 4.20.0, 4.21.0, 4.22.0},
   ghc-options:
     -Weverything
-    -- This one just reports unfixable things, AFAICT.
-    -Wno-all-missed-specialisations
     -- Type inference good.
     -Wno-missing-local-signatures
     -- Warns even when `Unsafe` is explicit, not inferred. See

--- a/hedgehog/src/Yaya/Hedgehog.hs
+++ b/hedgehog/src/Yaya/Hedgehog.hs
@@ -25,6 +25,7 @@ evalNonterminating ::
 evalNonterminating =
   maybe HH.success (const HH.failure <=< HH.annotateShow)
     <=< HH.evalIO . timeout 1_000_000 . evaluate
+{-# INLINEABLE evalNonterminating #-}
 
 -- | Returns success if the expression doesn’t terminate, failure otherwise.
 --   The value passed here should termina

--- a/hedgehog/src/Yaya/Hedgehog/Fold.hs
+++ b/hedgehog/src/Yaya/Hedgehog/Fold.hs
@@ -110,6 +110,7 @@ law_cataCompose Proxy φ ε =
   uncurry (===)
     . bimap (cata φ . cata (embed . ε :: f u -> u)) (cata (φ . ε))
     . diagonal
+{-# INLINEABLE law_cataCompose #-}
 
 -- | Creates a generator for any `Steppable` type whose pattern functor has
 --   terminal cases (e.g., not `Data.Functor.Identity` or `((,) a)`). @leaf@ can
@@ -153,6 +154,7 @@ genAlgebra ::
   Algebra (->) Maybe (Gen t)
 genAlgebra leaf branch =
   maybe (fmap (embed . fmap absurd) leaf) (fmap embed . branch)
+{-# INLINEABLE genAlgebra #-}
 
 -- | Creates a generator for potentially-infinite values.
 genCorecursive :: (Corecursive (->) t f) => (a -> f a) -> Gen a -> Gen t
@@ -178,6 +180,7 @@ corecursiveIsUnsafe Proxy x =
     evalNonterminating . fst . project @_ @(t (Pair a)) $ ana (\y -> y :!: y) x
     -- but using a lazy functor loses this property
     Tuple.fst (project @_ @(t ((,) a)) $ ana (\y -> (y, y)) x) === x
+{-# INLINEABLE corecursiveIsUnsafe #-}
 
 -- | Show that using a `Corecursive` structure recursively can lead to
 --   non-termination.
@@ -203,3 +206,4 @@ recursiveIsUnsafe Proxy x =
     -- But again, if you use a lazy functor, you lose that property, and you can
     -- short-circuit.
     cata Tuple.fst (ana @_ @(t ((,) a)) (\y -> (y, y)) x) === x
+{-# INLINEABLE recursiveIsUnsafe #-}

--- a/hedgehog/yaya-hedgehog.cabal
+++ b/hedgehog/yaya-hedgehog.cabal
@@ -144,8 +144,6 @@ common defaults
     base ^>= {4.13.0, 4.14.0, 4.15.0, 4.16.0, 4.17.0, 4.18.0, 4.19.0, 4.20.0, 4.21.0, 4.22.0},
   ghc-options:
     -Weverything
-    -- This one just reports unfixable things, AFAICT.
-    -Wno-all-missed-specialisations
     -- Type inference good.
     -Wno-missing-local-signatures
     -- Warns even when `Unsafe` is explicit, not inferred. See

--- a/lens/yaya-lens.cabal
+++ b/lens/yaya-lens.cabal
@@ -147,8 +147,6 @@ common defaults
     base ^>= {4.13.0, 4.14.0, 4.15.0, 4.16.0, 4.17.0, 4.18.0, 4.19.0, 4.20.0, 4.21.0, 4.22.0},
   ghc-options:
     -Weverything
-    -- This one just reports unfixable things, AFAICT.
-    -Wno-all-missed-specialisations
     -- Type inference good.
     -Wno-missing-local-signatures
     -- Warns even when `Unsafe` is explicit, not inferred. See

--- a/quickcheck/yaya-quickcheck.cabal
+++ b/quickcheck/yaya-quickcheck.cabal
@@ -144,8 +144,6 @@ common defaults
     base ^>= {4.13.0, 4.14.0, 4.15.0, 4.16.0, 4.17.0, 4.18.0, 4.19.0, 4.20.0, 4.21.0, 4.22.0},
   ghc-options:
     -Weverything
-    -- This one just reports unfixable things, AFAICT.
-    -Wno-all-missed-specialisations
     -- Type inference good.
     -Wno-missing-local-signatures
     -- Warns even when `Unsafe` is explicit, not inferred. See

--- a/unsafe/src/Yaya/Unsafe/Fold/Instances.hs
+++ b/unsafe/src/Yaya/Unsafe/Fold/Instances.hs
@@ -66,6 +66,7 @@ instance (Functor f) => Recursive (->) (Cofix f) f where
 
 instance (Functor f, Foldable f, Eq1 f) => Eq (Cofix f) where
   (==) = recursiveEq
+  {-# INLINEABLE (==) #-}
 
 -- | @since 0.4.1.0
 instance (Functor f, Foldable f, Ord1 f) => Ord (Cofix f) where
@@ -76,12 +77,14 @@ instance (Functor f, Show1 f) => Show (Cofix f) where
 
 instance (Functor f) => Corecursive (->) (Mu f) f where
   ana = Unsafe.unsafeAna
+  {-# INLINEABLE ana #-}
 
 instance (Functor f) => Recursive (->) (Nu f) f where
   cata = Unsafe.unsafeCata
 
 instance (Functor f, Foldable f, Eq1 f) => Eq (Nu f) where
   (==) = recursiveEq
+  {-# INLINEABLE (==) #-}
 
 -- | @since 0.4.1.0
 instance (Functor f, Foldable f, Ord1 f) => Ord (Nu f) where

--- a/unsafe/yaya-unsafe.cabal
+++ b/unsafe/yaya-unsafe.cabal
@@ -149,8 +149,6 @@ common defaults
     base ^>= {4.13.0, 4.14.0, 4.15.0, 4.16.0, 4.17.0, 4.18.0, 4.19.0, 4.20.0, 4.21.0, 4.22.0},
   ghc-options:
     -Weverything
-    -- This one just reports unfixable things, AFAICT.
-    -Wno-all-missed-specialisations
     -- Type inference good.
     -Wno-missing-local-signatures
     -- Warns even when `Unsafe` is explicit, not inferred. See


### PR DESCRIPTION
Everything that `-Wall-missed-specialisations` complains about that we have control over.